### PR TITLE
Material params unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(HAVE_KOKKOS "Whether to use Kokkos for parallel execution" OFF)
 option(USE_PURE_MPI "Whether to use Pure MPI (no Trilinos)" OFF)
 option(HAVE_QTHREADS "Whether to use QThreads" OFF)
 option(NIMBLE_NVIDIA_BUILD "Whether to build Nimble with CUDA" OFF)
+option(NIMBLE_ENABLE_UNIT_TESTS "Whether to build Nimble with GTest testing" OFF)
 
 add_library(nimble)
 add_library(nimble::nimble ALIAS nimble)
@@ -161,6 +162,10 @@ include_directories(src)
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(examples)
+
+if(NIMBLE_ENABLE_UNIT_TESTS)
+  add_subdirectory(unit_tests)
+endif()
 
 install(TARGETS nimble EXPORT NimbleSMTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/nimble_kokkos_material_factory.cc
+++ b/src/nimble_kokkos_material_factory.cc
@@ -46,18 +46,19 @@
 #include <utility>
 #include <nimble_kokkos_defs.h>
 #include <nimble_kokkos_material_factory.h>
-#include <nimble_material_factory_util.h>
+#include <nimble_material.h>
 
 namespace nimble_kokkos {
 
 using nimble::Material;
 
 MaterialFactory::MaterialFactory()
-    : material_device(nullptr) {
+    : MaterialFactoryBase(),
+      material_device(nullptr) {
 }
 
 void MaterialFactory::parse_and_create(const std::string& mat_params, const int num_points) {
-  material_params = nimble::ParseMaterialParametersString(mat_params.c_str(), num_points);
+  material_params = ParseMaterialParametersString(mat_params.c_str(), num_points);
   create();
 }
 

--- a/src/nimble_kokkos_material_factory.h
+++ b/src/nimble_kokkos_material_factory.h
@@ -47,6 +47,8 @@
 #include <memory>
 #include <string>
 
+#include "nimble_material_factory.h"
+
 namespace nimble {
 class Material;
 struct NGPLAMEData;
@@ -55,7 +57,7 @@ class MaterialParameters;
 
 namespace nimble_kokkos {
 
-class MaterialFactory {
+class MaterialFactory : public nimble::MaterialFactoryBase {
  public:
   explicit MaterialFactory();
   virtual ~MaterialFactory() = default;
@@ -75,7 +77,7 @@ class MaterialFactory {
 
   std::shared_ptr<const nimble::MaterialParameters> material_params;
 
-  virtual void create();
+  virtual void create() override;
 };
 
 }

--- a/src/nimble_material.cc
+++ b/src/nimble_material.cc
@@ -41,11 +41,18 @@
 //@HEADER
 */
 
+#include <nimble_material_factory.h>
 #include "nimble_material.h"
 #include "nimble_utils.h"
 #include <sstream>
 
 namespace nimble {
+
+void ElasticMaterial::register_supported_material_parameters(MaterialFactoryBase& factory) {
+  factory.add_valid_double_parameter_name("bulk_modulus");
+  factory.add_valid_double_parameter_name("shear_modulus");
+  factory.add_valid_double_parameter_name("density");
+}
 
   ElasticMaterial::ElasticMaterial(MaterialParameters const & material_parameters)
     : Material(material_parameters), num_state_variables_(0), dim_(0), density_(0.0), bulk_modulus_(0.0), shear_modulus_(0.0) {
@@ -219,6 +226,12 @@ namespace nimble {
       material_tangent[offset + 34] = 0.0;
       material_tangent[offset + 35] = mu;
     }
+  }
+
+  void NeohookeanMaterial::register_supported_material_parameters(MaterialFactoryBase& factory) {
+    factory.add_valid_double_parameter_name("bulk_modulus");
+    factory.add_valid_double_parameter_name("shear_modulus");
+    factory.add_valid_double_parameter_name("density");
   }
 
   NeohookeanMaterial::NeohookeanMaterial(MaterialParameters const & material_parameters)

--- a/src/nimble_material_factory.cc
+++ b/src/nimble_material_factory.cc
@@ -48,12 +48,120 @@
 #include <vector>
 #include <nimble_material.h>
 #include <nimble_material_factory.h>
-#include <nimble_material_factory_util.h>
 #include <stddef.h>
 
 namespace nimble {
 
-MaterialFactory::MaterialFactory() {
+MaterialFactoryBase::MaterialFactoryBase()
+{
+  NeohookeanMaterial::register_supported_material_parameters(*this);
+  ElasticMaterial::register_supported_material_parameters(*this);
+}
+
+std::shared_ptr<MaterialParameters> MaterialFactoryBase::ParseMaterialParametersString(const char *material_parameters,
+                                                                                       const int num_material_points) const {
+
+  char material_name[MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+  int num_material_parameters = 0;
+  char all_material_parameter_names[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+  char material_double_parameter_names[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+  double material_double_parameter_values[MaterialParameters::MAX_NUM_MAT_PARAM];
+  char material_string_parameter_names[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+  char material_string_parameter_values[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+
+  // The first string is the material name, followed by the material properties (key-value pairs)
+
+  char all_material_parameter_value_strings[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
+  size_t string_length = strlen(material_parameters);
+  size_t sub_string_length = 0;
+  bool last_char_was_space = false;
+  bool is_material_name = true;
+  bool is_param_name = false;
+  bool is_param_value = false;
+
+  memset(material_name, 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+  for (int i = 0; i < MaterialParameters::MAX_NUM_MAT_PARAM; ++i) {
+    memset(all_material_parameter_value_strings[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+    memset(all_material_parameter_names[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+    memset(material_double_parameter_names[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+    material_double_parameter_values[i] = 0.0;
+    memset(material_string_parameter_names[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+    memset(material_string_parameter_values[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
+  }
+
+  for (int i = 0; i < string_length; ++i) {
+    char val = material_parameters[i];
+    if (val == ' ') {
+      if (!last_char_was_space) {
+        if (is_material_name) {
+          is_material_name = false;
+          is_param_name = true;
+          sub_string_length = 0;
+          num_material_parameters += 1;
+        } else if (is_param_name) {
+          is_param_name = false;
+          is_param_value = true;
+          sub_string_length = 0;
+        } else if (is_param_value) {
+          is_param_name = true;
+          is_param_value = false;
+          sub_string_length = 0;
+          num_material_parameters += 1;
+        }
+      }
+      last_char_was_space = true;
+    } else {
+      if (is_material_name) {
+        material_name[sub_string_length++] = val;
+      } else if (is_param_name) {
+        all_material_parameter_names[num_material_parameters - 1][sub_string_length++] = val;
+      } else if (is_param_value) {
+        all_material_parameter_value_strings[num_material_parameters - 1][sub_string_length++] = val;
+      }
+      last_char_was_space = false;
+    }
+  }
+
+  int num_material_double_parameters = 0;
+  int num_material_string_parameters = 0;
+  for (int i = 0; i < num_material_parameters; ++i) {
+    int name_len = StringLength(all_material_parameter_names[i]);
+    if (std::find(valid_double_parameter_names.begin(), valid_double_parameter_names.end(),
+                  all_material_parameter_names[i]) != valid_double_parameter_names.end()) {
+      for (int j = 0; j < name_len; ++j) {
+        material_double_parameter_names[num_material_double_parameters][j] = all_material_parameter_names[i][j];
+      }
+      material_double_parameter_values[num_material_double_parameters] = atof(all_material_parameter_value_strings[i]);
+      ++num_material_double_parameters;
+    } else if (std::find(valid_string_parameter_names.begin(), valid_string_parameter_names.end(),
+                         all_material_parameter_names[i]) != valid_string_parameter_names.end()) {
+      int len = StringLength(all_material_parameter_value_strings[i]);
+      for (int j = 0; j < name_len; ++j) {
+        material_string_parameter_names[num_material_string_parameters][j] = all_material_parameter_names[i][j];
+      }
+      for (int j = 0; j < len; ++j) {
+        material_string_parameter_values[num_material_string_parameters][j] = all_material_parameter_value_strings[i][j];
+      }
+      ++num_material_string_parameters;
+    } else {
+      std::string errMsg = "Invalid material parameter encountered: '"
+          + std::string(all_material_parameter_names[i]) + "'";
+      std::runtime_error err(errMsg);
+      throw err;
+    }
+  }
+
+  assert(num_material_double_parameters + num_material_string_parameters == num_material_parameters);
+
+  return std::make_shared<MaterialParameters>(material_name, num_material_double_parameters,
+                                              material_double_parameter_names, material_double_parameter_values,
+                                              num_material_string_parameters, material_string_parameter_names,
+                                              material_string_parameter_values, num_material_points);
+}
+
+MaterialFactory::MaterialFactory()
+    :
+    MaterialFactoryBase() {
 }
 
 void MaterialFactory::parse_and_create(const std::string &mat_params) {

--- a/src/nimble_material_factory.cc
+++ b/src/nimble_material_factory.cc
@@ -49,6 +49,7 @@
 #include <nimble_material.h>
 #include <nimble_material_factory.h>
 #include <stddef.h>
+#include <cassert>
 
 namespace nimble {
 

--- a/src/nimble_material_factory.h
+++ b/src/nimble_material_factory.h
@@ -44,8 +44,10 @@
 #ifndef SRC_NIMBLE_MATERIAL_FACTORY_H_
 #define SRC_NIMBLE_MATERIAL_FACTORY_H_
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace nimble {
 class Material;
@@ -54,7 +56,38 @@ class MaterialParameters;
 
 namespace nimble {
 
-class MaterialFactory {
+class MaterialFactoryBase {
+ private:
+  static inline void find_or_insert_string_in_vector(const std::string &str, std::vector<std::string> &vec) {
+    if (std::find(vec.begin(), vec.end(), str) == vec.end()) {
+      vec.push_back(str);
+    }
+  }
+
+ public:
+  MaterialFactoryBase();
+  virtual ~MaterialFactoryBase() = default;
+
+  virtual void create() = 0;
+
+  inline void add_valid_double_parameter_name(const char *name) {
+    find_or_insert_string_in_vector(std::string(name), valid_double_parameter_names);
+  }
+
+  inline void add_valid_string_parameter_name(const char *name) {
+    find_or_insert_string_in_vector(std::string(name), valid_string_parameter_names);
+  }
+
+ protected:
+  std::shared_ptr<nimble::MaterialParameters> ParseMaterialParametersString(const char *material_parameters,
+                                                                            const int num_material_points = 0) const;
+
+ private:
+  std::vector<std::string> valid_double_parameter_names;
+  std::vector<std::string> valid_string_parameter_names;
+};
+
+class MaterialFactory : public MaterialFactoryBase {
  public:
   MaterialFactory();
   virtual ~MaterialFactory() = default;
@@ -64,7 +97,7 @@ class MaterialFactory {
   inline std::shared_ptr<Material> get_material() const { return material; }
 
  protected:
-  virtual void create();
+  virtual void create() override;
 
   std::shared_ptr<Material> material;
 

--- a/src/nimble_material_factory_util.cc
+++ b/src/nimble_material_factory_util.cc
@@ -46,80 +46,10 @@
 #include <memory>
 #include <nimble_material.h>
 #include <stddef.h>
+#include <algorithm>
+#include <cassert>
 
 namespace nimble {
-
-std::shared_ptr<nimble::MaterialParameters> ParseMaterialParametersString(const char *material_parameters,
-                                                                          const int num_material_points) {
-
-  char material_name[MaterialParameters::MAX_MAT_MODEL_STR_LEN];
-  int num_material_parameters;
-  char material_parameter_names[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
-  double material_parameter_values[MaterialParameters::MAX_NUM_MAT_PARAM];
-
-  num_material_parameters = 0;
-
-  // The first string is the material name, followed by the material properties (key-value pairs)
-
-  char material_parameter_value_strings[MaterialParameters::MAX_NUM_MAT_PARAM][MaterialParameters::MAX_MAT_MODEL_STR_LEN];
-  size_t string_length = strlen(material_parameters);
-  size_t sub_string_length = 0;
-  bool last_char_was_space = false;
-  bool is_material_name = true;
-  bool is_param_name = false;
-  bool is_param_value = false;
-
-  memset(material_name, 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
-  for (int i=0 ; i<MaterialParameters::MAX_NUM_MAT_PARAM ; ++i) {
-    memset(material_parameter_names[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
-    memset(material_parameter_value_strings[i], 0, MaterialParameters::MAX_MAT_MODEL_STR_LEN);
-    material_parameter_values[i] = 0.0;
-  }
-
-  for (int i=0 ; i<string_length ; ++i) {
-    char val = material_parameters[i];
-    if (val == ' ') {
-      if (!last_char_was_space) {
-        if (is_material_name) {
-          is_material_name = false;
-          is_param_name = true;
-          sub_string_length = 0;
-          num_material_parameters += 1;
-        }
-        else if (is_param_name) {
-          is_param_name = false;
-          is_param_value = true;
-          sub_string_length = 0;
-        }
-        else if (is_param_value) {
-          is_param_name = true;
-          is_param_value = false;
-          sub_string_length = 0;
-          num_material_parameters += 1;
-        }
-      }
-      last_char_was_space = true;
-    }
-    else {
-      if (is_material_name) {
-        material_name[sub_string_length++] = val;
-      }
-      else if (is_param_name) {
-        material_parameter_names[num_material_parameters - 1][sub_string_length++] = val;
-      }
-      else if (is_param_value) {
-        material_parameter_value_strings[num_material_parameters - 1][sub_string_length++] = val;
-      }
-      last_char_was_space = false;
-    }
-  }
-  for (int i=0 ; i<num_material_parameters; ++i) {
-    material_parameter_values[i] = atof(material_parameter_value_strings[i]);
-  }
-
-  return std::make_shared<MaterialParameters>(material_name, num_material_parameters, material_parameter_names,
-                                              material_parameter_values, num_material_points);
-}
 
 }
 

--- a/src/nimble_material_factory_util.h
+++ b/src/nimble_material_factory_util.h
@@ -50,6 +50,8 @@
 namespace nimble {
 
 std::shared_ptr<nimble::MaterialParameters> ParseMaterialParametersString(const char *material_parameters,
+                                                                          const std::vector<std::string>& valid_double_names,
+                                                                          const std::vector<std::string>& valid_string_names,
                                                                           const int num_material_points = 0);
 
 }

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+include(CTest)
+
+find_package(GTest REQUIRED)
+include(GoogleTest)
+
+set(NIMBLE_UNIT_SOURCES test_nimble_material_params.cc nimble_unit_main.cc)
+
+add_executable(NimbleSM_Unit ${NIMBLE_UNIT_SOURCES})
+
+gtest_discover_tests(NimbleSM_Unit)
+
+target_include_directories(NimbleSM_Unit PRIVATE ${GTEST_INCLUDE_DIR})
+target_link_libraries(NimbleSM_Unit PRIVATE nimble::nimble ${GTEST_LIBRARY})

--- a/unit_tests/nimble_unit_main.cc
+++ b/unit_tests/nimble_unit_main.cc
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                                NimbleSM
+//                             Copyright 2018
+//   National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL NTESS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions?  Contact David Littlewood (djlittl@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  int err = RUN_ALL_TESTS();
+
+  return err;
+}

--- a/unit_tests/test_nimble_material_params.cc
+++ b/unit_tests/test_nimble_material_params.cc
@@ -40,13 +40,98 @@
 //@HEADER
 
 #include <gtest/gtest.h>
-
-#include "nimble_material.h"
+#include <nimble_material.h>
+#include <nimble_material_factory.h>
+#include <nimble_material_factory_util.h>
+#include <memory>
+#include <string>
 
 namespace nimble {
 
 TEST(nimble_material_params, construct) {
   nimble::MaterialParameters params;
+}
+
+TEST(nimble_material_params, add_double_parameter) {
+  nimble::MaterialParameters params;
+  params.AddParameter("testParam", 1.0);
+
+  ASSERT_TRUE(params.IsParameter("testParam"));
+  ASSERT_DOUBLE_EQ(params.GetParameterValue("testParam"), 1.0);
+}
+
+class TestMaterialFactory : public MaterialFactoryBase {
+ public:
+  TestMaterialFactory()
+      :
+      MaterialFactoryBase() {
+  }
+  ~TestMaterialFactory() = default;
+
+  void register_test_double_parameter(const char* name) {
+    add_valid_double_parameter_name(name);
+  }
+
+  void register_test_string_parameter(const char* name) {
+    add_valid_string_parameter_name(name);
+  }
+
+  std::shared_ptr<MaterialParameters> parse_string(const char *params) const {
+    return ParseMaterialParametersString(params);
+  }
+
+  void create() override {}
+};
+
+TEST(nimble_material_params, invalid_parameter_throws) {
+  const std::string material_string = "neohookean some_stuff 1.0e6 stuff 0.27 density 1.0e3";
+  EXPECT_ANY_THROW(
+      TestMaterialFactory().parse_string(material_string.c_str()));
+
+}
+
+TEST(nimble_material_params, parse_double_parameters) {
+  const std::string material_string = "neohookean bulk_modulus 1.0e6 shear_modulus 5.e5 density 1.0e3";
+  auto params = TestMaterialFactory().parse_string(material_string.c_str());
+
+  char matName[64];
+  params->GetMaterialName(matName, false);
+  std::string stringMatName(matName);
+  ASSERT_EQ(stringMatName, "neohookean");
+
+  ASSERT_EQ(params->GetNumParameters(), 3);
+  ASSERT_EQ(params->GetNumStringParameters(), 0);
+
+  ASSERT_FALSE(params->IsParameter("testParam"));
+
+  ASSERT_TRUE(params->IsParameter("bulk_modulus"));
+  ASSERT_TRUE(params->IsParameter("density"));
+  ASSERT_TRUE(params->IsParameter("shear_modulus"));
+
+  EXPECT_DOUBLE_EQ(params->GetParameterValue("bulk_modulus"), 1.0e6);
+  EXPECT_DOUBLE_EQ(params->GetParameterValue("shear_modulus"), 5.e5);
+  EXPECT_DOUBLE_EQ(params->GetParameterValue("density"), 1.0e3);
+}
+
+TEST(nimble_material_params, register_new_test_property) {
+  const std::string material_string = "neohookean bulk_modulus 1.0e6 shear_modulus 5.e5 density 1.0e3 test_property 2.0";
+  TestMaterialFactory fact;
+  fact.register_test_double_parameter("test_property");
+  auto params = fact.parse_string(material_string.c_str());
+
+  ASSERT_TRUE(params->IsParameter("test_property"));
+  EXPECT_DOUBLE_EQ(params->GetParameterValue("test_property"), 2.0);
+}
+
+TEST(nimble_material_params, register_new_test_string_property) {
+  const std::string material_string = "neohookean bulk_modulus 1.0e6 shear_modulus 5.e5 density 1.0e3 test_property custom_property_val";
+  TestMaterialFactory fact;
+  fact.register_test_string_parameter("test_property");
+  auto params = fact.parse_string(material_string.c_str());
+
+  ASSERT_TRUE(params->IsStringParameter("test_property"));
+  auto c = params->GetStringParameterValue("test_property");
+  EXPECT_EQ(std::string(params->GetStringParameterValue("test_property")), "custom_property_val");
 }
 
 }

--- a/unit_tests/test_nimble_material_params.cc
+++ b/unit_tests/test_nimble_material_params.cc
@@ -1,0 +1,53 @@
+//@HEADER
+// ************************************************************************
+//
+//                                NimbleSM
+//                             Copyright 2018
+//   National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+//
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government
+// retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL NTESS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions?  Contact David Littlewood (djlittl@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#include <gtest/gtest.h>
+
+#include "nimble_material.h"
+
+namespace nimble {
+
+TEST(nimble_material_params, construct) {
+  nimble::MaterialParameters params;
+}
+
+}
+


### PR DESCRIPTION
Depend on GTest for unit testing. Add some basic testing of MaterialParameters and enable string parameters. This is needed for more complex material modeling, such as that in the LAMÉ library. Perhaps should open an issue related to allowing use of STL containers in these data structures rather than raw C types.

I need a hand with setting up the CI stuff for GTest dependency and CMake configuration that enables unit testing. I hope people will find having a unit testing setup valuable, though! Please add unit tests of your new code!