### PR TITLE
Fix caching of Trilinos

### DIFF
--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:  
       - master
-      - fix/44-caching-trilinos
 
   pull_request:
 

--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -31,12 +31,17 @@ jobs:
            sudo apt-get install -y openmpi-bin libopenmpi-dev
            sudo apt-get install -y netcdf-bin libnetcdf-dev
            sudo apt-get install -y libhdf5-serial-dev libhdf5-mpich-dev
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+      shell: bash
     - name: Cache Trilinos
       id: cache-trilinos
       uses: actions/cache@v2
       with:
         path: Trilinos/
-        key: ${{ runner.os }}-trilinos
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-trilinos
     - name: Build Trilinos
       if: steps.cache-trilinos.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -30,17 +30,12 @@ jobs:
            sudo apt-get install -y openmpi-bin libopenmpi-dev
            sudo apt-get install -y netcdf-bin libnetcdf-dev
            sudo apt-get install -y libhdf5-serial-dev libhdf5-mpich-dev
-    - name: Get Date
-      id: get-date
-      run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      shell: bash
     - name: Cache Trilinos
       id: cache-trilinos
       uses: actions/cache@v2
       with:
         path: Trilinos/
-        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-trilinos
+        key: ${{ runner.os }}-trilinos
     - name: Build Trilinos
       if: steps.cache-trilinos.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:  
       - master
+      - fix/44-caching-trilinos
 
   pull_request:
 


### PR DESCRIPTION
Closes #44 

The name of the cache file was updated. Now the cache lasts up to one month.

The previous version was using a daily key for the filename, which resulted in rebuilding Trilinos a daily basis (when a pull request was submitted).