### PR TITLE
interface change to return gap (and unit normal) from CPP

### DIFF
--- a/src/contact/parallel/bvh_contact_manager.cc
+++ b/src/contact/parallel/bvh_contact_manager.cc
@@ -19,23 +19,20 @@ namespace nimble {
         query_tree_local( tree, elb, [&_a, &_b, &elb, &res, this]( std::size_t _i ) {
           const auto &face = _a.elements[_i];
           const auto &node = elb;
-          ContactEntity::vertex closest_point;
           ContactManager::PROJECTION_TYPE proj_type;
-          contact_manager->ClosestPointProjectionSingle( node, face, &closest_point, &proj_type,
-              1.0e-16 );
-
-          // Compute distance
-          double dx = node.coord_1_x_ - closest_point[0];
-          double dy = node.coord_1_y_ - closest_point[1];
-          double dz = node.coord_1_z_ - closest_point[2];
-          double gap = std::sqrt( dx * dx + dy * dy + dz * dz );
-
-          if ( gap <= 0.15 * ( node.char_len_ + face.char_len_ ) ) {
-            auto &entry = res.emplace_back();
-            entry.first_global_id = face.contact_entity_global_id();
-            entry.second_global_id = node.contact_entity_global_id();
-            entry.gap = gap;
-          }
+          ContactEntity::vertex closest_point;
+          double gap;
+          double normal[3];
+          contact_manager->ClosestPointProjectionSingle( node, face, 
+            &proj_type, &closest_point, gap, &normal);
+          if ( proj_type != ContactManager::PROJECTION_TYPE::UNKNOWN ) {
+            if ( gap <= 0.15 * ( node.char_len_ + face.char_len_ ) ) {
+              auto &entry = res.emplace_back();
+              entry.first_global_id = face.contact_entity_global_id();
+              entry.second_global_id = node.contact_entity_global_id();
+              entry.gap = gap;
+            }
+          };
         } );
 
       return res;

--- a/src/nimble_contact_manager.cc
+++ b/src/nimble_contact_manager.cc
@@ -1163,6 +1163,7 @@ namespace nimble {
     }
   }
 
+
   void
   ContactManager::ClosestPointProjectionSingle(const ContactEntity &node,
                                      const ContactEntity &tri,
@@ -1331,11 +1332,14 @@ namespace nimble {
   }
 
   void
-  ContactManager::SimpleClosestPointProjectionSingle(const ContactEntity &node,
-                                     const ContactEntity &tri,
-                                     ContactEntity::vertex *closest_point,
-                                     PROJECTION_TYPE *projection_type,
-                                     double tol) {
+  ContactManager::SimpleClosestPointProjectionSingle(
+        const ContactEntity &node,
+        const ContactEntity &tri,
+        PROJECTION_TYPE *projection_type,
+        ContactEntity::vertex *closest_point,
+        double &gap,
+        double *normal,
+        double tol) {
     // node
     double p[3];
     p[0] = node.coord_1_x_;
@@ -1379,10 +1383,21 @@ namespace nimble {
     bool a3 = (alpha3 > -tol && alpha3 < tol2);
     *projection_type = PROJECTION_TYPE::UNKNOWN; // indicates outside
     if (a1 && a2 && a3) {
-      closest_point->coords_[0] = alpha1*p1[0] + alpha2*p2[0] + alpha3*p3[0];
-      closest_point->coords_[1] = alpha1*p1[1] + alpha2*p2[1] + alpha3*p3[1];
-      closest_point->coords_[2] = alpha1*p1[2] + alpha2*p2[2] + alpha3*p3[2];
       *projection_type = PROJECTION_TYPE::FACE;
+      double xp = alpha1*p1[0] + alpha2*p2[0] + alpha3*p3[0];
+      double yp = alpha1*p1[1] + alpha2*p2[1] + alpha3*p3[1];
+      double zp = alpha1*p1[2] + alpha2*p2[2] + alpha3*p3[2];
+      closest_point->coords_[0] = xp;
+      closest_point->coords_[1] = yp;
+      closest_point->coords_[2] = zp;
+      double dx = node.coord_1_x_ - xp;
+      double dy = node.coord_1_y_ - yp;
+      double dz = node.coord_1_z_ - zp;
+      double s = 1.0/std::sqrt(n_squared);
+      normal[0] = n[0]*s;
+      normal[1] = n[1]*s;
+      normal[2] = n[2]*s;
+      gap = dx*normal[0] + dy*normal[1] + dz*normal[2];
     }
   }
 

--- a/src/nimble_contact_manager.h
+++ b/src/nimble_contact_manager.h
@@ -160,11 +160,14 @@ namespace nimble {
         ContactEntity::vertex *closest_point,
         PROJECTION_TYPE *projection_type,
         double tolerance);
+
     void SimpleClosestPointProjectionSingle( const ContactEntity &node,
         const ContactEntity &tri,
-        ContactEntity::vertex *closest_point,
         PROJECTION_TYPE *projection_type,
-        double tolerance);
+        ContactEntity::vertex *closest_point,
+        double &gap,
+        double *normal,
+        double tolerance = 1.e-8);
 
     virtual void InitializeContactVisualization(std::string const & contact_visualization_exodus_file_name);
 


### PR DESCRIPTION
change projection interface to 

SimpleClosestPointProjectionSingle(
        const ContactEntity &node,
        const ContactEntity &tri,
        PROJECTION_TYPE *projection_type,
        ContactEntity::vertex *closest_point,
        double &gap,
        double *normal,
        double tol)

and changed parallel/bvh_contact_manager.cc accordingly. 

>> Did not see other usage e.g. for ArborX interface <<

all active tests pass with -DUSE_PURE_MPI=TRUE