### PR TITLE
remove rescaling of penalty and  adjust penalty values in benchmarks

### DIFF
--- a/src/contact/parallel/arborx_parallel_contact_manager.cc
+++ b/src/contact/parallel/arborx_parallel_contact_manager.cc
@@ -126,10 +126,7 @@ struct ContactCallback
     double force[dim] = {0., 0., 0.};
     if (inside) {
       //
-      // Factor 3 is related to `const int numNodeFaces = 3`
-      // in nimble::details::PenaltyContactEnforcement
-      //
-      details::getContactForce(penalty_ / static_cast<double>(3), gap, normal, force);
+      details::getContactForce(penalty_, gap, normal, force);
       //
       auto result = list_.insert(PairData{p_data.rank_, p_data.index_, rank_, f_primitive});
       if (result.second) { // if the insertion took place

--- a/src/nimble_contact_manager.h
+++ b/src/nimble_contact_manager.h
@@ -103,9 +103,8 @@ struct PenaltyContactEnforcement {
                       const double normal[3], 
                       const double barycentric_coordinates[3],
                       VecType &full_contact_force) const {
-      const int numNodeFaces = 3 ; // NOTE for compatibilty only
       double contact_force[3] { };
-      details::getContactForce(penalty / numNodeFaces, gap, normal, contact_force);
+      details::getContactForce(penalty, gap, normal, contact_force);
       //
       face.SetNodalContactForces(contact_force, barycentric_coordinates);
       node.SetNodalContactForces(contact_force);

--- a/test/cubes_contact/cubes_contact.in
+++ b/test/cubes_contact/cubes_contact.in
@@ -18,5 +18,5 @@ boundary condition:               initial_velocity    nodelist_200 z 1.0
 # make it easy by only allowing normal motion
 boundary condition:               prescribed_velocity nodelist_300 x 0.0
 boundary condition:               prescribed_velocity nodelist_300 y 0.0
-contact:                          master_blocks block_2 slave_blocks block_1 penalty_parameter 1.0e12
+contact:                          master_blocks block_2 slave_blocks block_1 penalty_parameter 0.33333333333333333333333333333e12
 contact visualization:            visualize_contact_entities on visualize_bounding_boxes on file_name vis.e

--- a/test/sphere_plate_contact/sphere_plate_contact.in
+++ b/test/sphere_plate_contact/sphere_plate_contact.in
@@ -8,5 +8,5 @@ material parameters:              material_1 neohookean density 7.8e3 bulk_modul
 macroscale block:                 block_1 material_1
 macroscale block:                 block_2 material_1
 boundary condition:               initial_velocity nodelist_2 x 8.0e2
-contact:                          master_blocks block_2 slave_blocks block_1 penalty_parameter 1.0e12
+contact:                          master_blocks block_2 slave_blocks block_1 penalty_parameter 0.3333333333333333333333333333333e12
 #contact visualization:            visualize_contact_entities on visualize_bounding_boxes on file_name vis.e


### PR DESCRIPTION
two line clean up of seemingly useless rescale of contact penalty parameter
adjusted penalty value in the two benchmarks that use it -- did not test parallel arborX build since I'm not sure how to build it yet (will trust CI)