### PR TITLE
Add Release flag for all the Nimble builds

### DIFF
--- a/.github/workflows/ubuntu-arborx-mpi.yml
+++ b/.github/workflows/ubuntu-arborx-mpi.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         run: |
            mkdir build && cd build
-           cmake -DCMAKE_CXX_FLAGS="-Werror" \
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
                  -Dexodus_INCLUDE_DIR="/usr/include" \
                  -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \
                  -DHAVE_KOKKOS=ON -DHAVE_ARBORX=ON -DUSE_PURE_MPI=ON \

--- a/.github/workflows/ubuntu-arborx-serial.yml
+++ b/.github/workflows/ubuntu-arborx-serial.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         run: |
            mkdir build && cd build
-           cmake -DCMAKE_CXX_FLAGS="-Werror" \
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
                  -Dexodus_INCLUDE_DIR="/usr/include" \
                  -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \
                  -DHAVE_KOKKOS=ON -DHAVE_ARBORX=ON -DUSE_PURE_MPI=OFF \

--- a/.github/workflows/ubuntu-kokkos-mpi.yml
+++ b/.github/workflows/ubuntu-kokkos-mpi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CMAKE_BUILD_TYPE: release
+      CMAKE_BUILD_TYPE: Release
 
     steps:
     - uses: actions/checkout@v1
@@ -45,7 +45,7 @@ jobs:
       run: |
            export ACCESS=`pwd`
            mkdir build && cd build
-           cmake -DCMAKE_CXX_FLAGS="-Werror" \
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
                  -DUSE_PURE_MPI=ON \
                  -Dexodus_INCLUDE_DIR="/usr/include" \
                  -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \

--- a/.github/workflows/ubuntu-kokkos-serial.yml
+++ b/.github/workflows/ubuntu-kokkos-serial.yml
@@ -14,7 +14,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     env:
-      CMAKE_BUILD_TYPE: release
+      CMAKE_BUILD_TYPE: Release
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
            mkdir build && cd build
-           cmake -DCMAKE_CXX_FLAGS="-Werror" \
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
                  -Dexodus_INCLUDE_DIR="/usr/include" \
                  -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \
                  -DHAVE_KOKKOS=ON \

--- a/.github/workflows/ubuntu-mpi.yml
+++ b/.github/workflows/ubuntu-mpi.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CMAKE_BUILD_TYPE: release
+      CMAKE_BUILD_TYPE: Release
 
     steps:
     - uses: actions/checkout@v1
@@ -36,7 +36,10 @@ jobs:
       run: |
            mkdir build && cd build
            export ACCESS=`pwd`
-           cmake -DCMAKE_CXX_FLAGS="-Werror" -DUSE_PURE_MPI=ON -Dexodus_INCLUDE_DIR="/usr/include" -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" ..
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
+                 -DUSE_PURE_MPI=ON -Dexodus_INCLUDE_DIR="/usr/include" \
+                 -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \
+                 ..
     - name: build
       run: cmake --build build
     - name: test

--- a/.github/workflows/ubuntu-serial.yml
+++ b/.github/workflows/ubuntu-serial.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CMAKE_BUILD_TYPE: release
+      CMAKE_BUILD_TYPE: Release
 
     steps:
     - uses: actions/checkout@v1
@@ -35,7 +35,10 @@ jobs:
       run: |
            mkdir build && cd build
            export ACCESS=`pwd`
-           cmake -DCMAKE_CXX_FLAGS="-Werror" -Dexodus_INCLUDE_DIR="/usr/include" -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" ..
+           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
+                 -Dexodus_INCLUDE_DIR="/usr/include" \
+                 -Dexodus_LIBRARY="/usr/lib/x86_64-linux-gnu/libexodus.so" \
+                 ..
     - name: build
       run: cmake --build build
     - name: test

--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CMAKE_BUILD_TYPE: release
+      CMAKE_BUILD_TYPE: Release
 
     steps:
     - uses: actions/checkout@v1
@@ -66,7 +66,8 @@ jobs:
       run: |
         export ACCESS=`pwd`
         mkdir build && cd build
-        cmake -DCMAKE_CXX_FLAGS="-Werror" -DHAVE_TRILINOS=ON -DUSE_PURE_MPI=ON \
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Werror" \
+              -DHAVE_TRILINOS=ON -DUSE_PURE_MPI=ON \
               ..
     - name: Build NimbleSM
       run: |


### PR DESCRIPTION
Close #89

Building explicitly in Release mode all the CI tests
Now the timings should be more reasonable.