### PR TITLE
nimble_kokkos: add Kokkos profiling regions

### DIFF
--- a/src/nimble_kokkos_profiling.h
+++ b/src/nimble_kokkos_profiling.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <nimble_kokkos_defs.h>
+#include <string>
+
+namespace nimble_kokkos {
+
+class ProfilingTimer {
+public:
+  inline ProfilingTimer() = default;
+
+  inline void push_region(const std::string &profiling_region_name) {
+    Kokkos::Profiling::pushRegion("NimbleSM: " + profiling_region_name);
+    timer.reset();
+  }
+
+  inline double pop_region_and_report_time() const {
+    double t = timer.seconds();
+    Kokkos::Profiling::popRegion();
+    return t;
+  }
+
+private:
+  Kokkos::Timer timer;
+};
+
+} // namespace nimble_kokkos

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -5,24 +5,29 @@ include(CTest)
 include(GoogleTest)
 include(FetchContent)
 
+set(NIMBLE_USE_LOCAL_GTEST OFF CACHE BOOL "Whether to use local GTest or fetch from Github")
 
-# Fetch Google Test
-set(GOOGLETEST_VERSION 1.10.0)
-set(GOOGLETEST_GIT_URL https://github.com/google/googletest.git)
+if (NIMBLE_USE_LOCAL_GTEST)
+  message("- Using local Google Test")
+  find_package(GTest REQUIRED)
+else()
+  # Fetch Google Test
+  set(GOOGLETEST_VERSION 1.10.0)
+  set(GOOGLETEST_GIT_URL https://github.com/google/googletest.git)
 
-message("- Using FetchContent to get Google Test version ${GOOGLETEST_VERSION} from ${GOOGLETEST_GIT_URL}")
+  message("- Using FetchContent to get Google Test version ${GOOGLETEST_VERSION} from ${GOOGLETEST_GIT_URL}")
 
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY ${GOOGLETEST_GIT_URL}
-        GIT_TAG        release-${GOOGLETEST_VERSION}
-)
+  FetchContent_Declare(
+          googletest
+          GIT_REPOSITORY ${GOOGLETEST_GIT_URL}
+          GIT_TAG        release-${GOOGLETEST_VERSION}
+  )
 
-FetchContent_MakeAvailable(googletest)
+  FetchContent_MakeAvailable(googletest)
+endif()
 
 message(" * gtest sources dir: ${gtest_SOURCE_DIR}")
 message(" * gtest binary dir:  ${gtest_BINARY_DIR}")
-
 
 # Configure tests
 message("- Configure tests")
@@ -49,7 +54,12 @@ add_executable(NimbleSM_Unit ${NIMBLE_UNIT_SOURCES})
 message(" * Link nimble library")
 target_link_libraries(NimbleSM_Unit nimble::nimble)
 message(" * Link gtest libraries")
-target_link_libraries(NimbleSM_Unit gtest gtest_main)
+if (NIMBLE_USE_LOCAL_GTEST)
+  target_include_directories(NimbleSM_Unit PRIVATE ${GTEST_INCLUDE_DIR})
+  target_link_libraries(NimbleSM_Unit nimble::nimble ${GTEST_LIBRARY})
+else()
+  target_link_libraries(NimbleSM_Unit gtest gtest_main)
+endif()
 
 message(" * Link other libraries")
 


### PR DESCRIPTION
for easier gathering of timing data via kokkos-tools.

TBD: this kind of clashes with some of the manual timers that were added. Pick one or the other? Kokkos::Profiling regions work together much more seamlessly with named Views and kernels (parallel_for, reduce, etc.)