### PR TITLE
performance of RemoveInternalSkinFaces

### DIFF
--- a/src/nimble_contact_manager.cc
+++ b/src/nimble_contact_manager.cc
@@ -399,7 +399,7 @@ namespace nimble {
           const auto *mpi_buff_ptr = &mpi_buffer.at(i_mpi_buff_face*num_nodes_in_face);
           bool found = true;
           for ( int j = 0; j < 4; ++j ) {
-            if (std::find_if(face_global_ids.begin(), face_global_ids.end(), [mpi_buff_ptr, j]( auto &&id ) {
+            if (std::find_if(face_global_ids.begin(), face_global_ids.end(), [mpi_buff_ptr, j]( int id ) {
                  return id == mpi_buff_ptr[j];
                } ) == face_global_ids.end() ) {
               found = false;

--- a/src/nimble_genesis_mesh.h
+++ b/src/nimble_genesis_mesh.h
@@ -82,6 +82,7 @@ namespace nimble {
     unsigned int GetNumNodes() const { return node_x_.size(); }
 
     const int * GetNodeGlobalIds() const { return &node_global_id_[0]; }
+    std::size_t GetNumNodeGlobalIds() const { return node_global_id_.size(); }
 
     int GetMaxNodeGlobalId() const {
       int max_id = -1;


### PR DESCRIPTION
Optimizes the performance of RemoveInternalSkinFaces in ContactManager to remove multiple repeated AllReduce/BCasts and replace with a node number shift algorithm, where each node removes received duplicate faces and then propagates them to the next node.

This function is important for preventing spurious collisions with internal faces due to decomposition in MPI mode