### PR TITLE
126 - Replace ubuntu latest with numbered version

### DIFF
--- a/.github/workflows/ubuntu-arborx-mpi.yml
+++ b/.github/workflows/ubuntu-arborx-mpi.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       CMAKE_BUILD_TYPE: release
     steps:

--- a/.github/workflows/ubuntu-arborx-serial.yml
+++ b/.github/workflows/ubuntu-arborx-serial.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       CMAKE_BUILD_TYPE: release
     steps:

--- a/.github/workflows/ubuntu-kokkos-mpi.yml
+++ b/.github/workflows/ubuntu-kokkos-mpi.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/ubuntu-kokkos-serial.yml
+++ b/.github/workflows/ubuntu-kokkos-serial.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       CMAKE_BUILD_TYPE: Release
     steps:

--- a/.github/workflows/ubuntu-mpi.yml
+++ b/.github/workflows/ubuntu-mpi.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/ubuntu-serial.yml
+++ b/.github/workflows/ubuntu-serial.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:  
       - master
-      - bug/replace-ubuntu-latest-with-number
   pull_request:
 
   workflow_dispatch:

--- a/.github/workflows/ubuntu-serial.yml
+++ b/.github/workflows/ubuntu-serial.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:  
       - master
+      - bug/replace-ubuntu-latest-with-number
   pull_request:
 
   workflow_dispatch:
@@ -13,7 +14,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -14,7 +14,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       CMAKE_BUILD_TYPE: Release


### PR DESCRIPTION
Closes #126 

SEACAS PPA does not have a release for "focal" (= Ubuntu 20.04 LTS = 'ubuntu-latest')
We specify version 18.04 for using the PPA.