### PR TITLE
Added a helper parser function to material factory given input string

### DIFF
--- a/src/nimble_material_factory.cc
+++ b/src/nimble_material_factory.cc
@@ -117,4 +117,40 @@ void MaterialFactory::create() {
   }
 }
 
+std::map<std::string, double> MaterialFactory::parse_material_params_string(const std::string& mat_params) {
+  return ParseMaterialParamsStringToMap(mat_params);
+}
+
+std::map<std::string, double> MaterialFactoryBase::ParseMaterialParamsStringToMap(const std::string& material_parameters) const {
+  auto tokens = nimble::tokenize_string(material_parameters);
+
+  // The first string is the material name, followed by the material properties (key-value pairs)
+  assert(tokens.size() > 1);
+
+  const std::string material_name = tokens.front();
+  auto token = tokens.cbegin() + 1;
+  auto tokens_end = tokens.cend();
+
+  std::map<std::string, std::string> material_string_parameters;
+  std::map<std::string, double> material_double_parameters;
+  for (; token != tokens_end; token += 2) { 
+    auto&& key = *token;
+    auto&& val = *(token+1);
+    if (std::find(valid_double_parameter_names.begin(), valid_double_parameter_names.end(), key)
+        != valid_double_parameter_names.end()) {
+      double double_val = nimble::string_to_double(val);
+      material_double_parameters.insert(std::make_pair(key, double_val));
+    } else if (std::find(valid_string_parameter_names.begin(), valid_string_parameter_names.end(),
+                         key) != valid_string_parameter_names.end()) {
+      material_string_parameters.insert(std::make_pair(key, val));
+    } else {
+      std::string errMsg = "Invalid material parameter encountered: '" + key + "'";
+      std::runtime_error err(errMsg);
+      throw err;
+    }
+  }
+
+  return material_double_parameters;
+}
+
 }

--- a/src/nimble_material_factory.h
+++ b/src/nimble_material_factory.h
@@ -48,6 +48,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace nimble {
 class Material;
@@ -82,6 +83,8 @@ class MaterialFactoryBase {
   std::shared_ptr<nimble::MaterialParameters> ParseMaterialParametersString(const std::string& material_parameters,
                                                                             const int num_material_points = 0) const;
 
+  std::map<std::string, double> ParseMaterialParamsStringToMap(const std::string& material_parameters) const;
+
  private:
   std::vector<std::string> valid_double_parameter_names;
   std::vector<std::string> valid_string_parameter_names;
@@ -93,6 +96,8 @@ class MaterialFactory : public MaterialFactoryBase {
   virtual ~MaterialFactory() = default;
 
   void parse_and_create(const std::string& mat_params);
+
+  std::map<std::string, double> parse_material_params_string(const std::string& material_parameters);
 
   inline std::shared_ptr<Material> get_material() const { return material; }
 

--- a/src/nimble_mpi.cc
+++ b/src/nimble_mpi.cc
@@ -217,7 +217,7 @@ int NimbleMPIMain(std::shared_ptr<nimble::MaterialFactory> material_factory,
       std::string uq_params_this_material = it->second;
       std::string const & nominal_params_string = parser->GetMacroscaleMaterialParameters(block_id);
       bool block_id_present = std::find(block_ids.begin(), block_ids.end(), block_id) != block_ids.end() ;
-      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks[block_id] );
+      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks );
     }
     // initialize
     uq_model.Initialize(mesh,model_data);

--- a/src/nimble_mpi.cc
+++ b/src/nimble_mpi.cc
@@ -215,7 +215,9 @@ int NimbleMPIMain(std::shared_ptr<nimble::MaterialFactory> material_factory,
       std::string material_key = it->first;
       int block_id = parser->GetBlockIdFromMaterial( material_key );
       std::string uq_params_this_material = it->second;
-      uq_model.ParseBlockInput( uq_params_this_material, block_id, blocks[block_id] );
+      std::string const & nominal_params_string = parser->GetMacroscaleMaterialParameters(block_id);
+      bool block_id_present = std::find(block_ids.begin(), block_ids.end(), block_id) != block_ids.end() ;
+      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks[block_id] );
     }
     // initialize
     uq_model.Initialize(mesh,model_data);

--- a/src/nimble_serial.cc
+++ b/src/nimble_serial.cc
@@ -187,7 +187,7 @@ int NimbleSerialMain(std::shared_ptr<nimble::MaterialFactory> material_factory,
       std::string uq_params_this_material = it->second;
       std::string const & nominal_params_string = parser->GetMacroscaleMaterialParameters(block_id);
       bool block_id_present = std::find(block_ids.begin(), block_ids.end(), block_id) != block_ids.end() ;
-      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks[block_id] );
+      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks );
     }
     // initialize
     uq_model.Initialize(mesh,macroscale_data);

--- a/src/nimble_serial.cc
+++ b/src/nimble_serial.cc
@@ -185,7 +185,9 @@ int NimbleSerialMain(std::shared_ptr<nimble::MaterialFactory> material_factory,
       std::string material_key = it->first;
       int block_id = parser->GetBlockIdFromMaterial( material_key );
       std::string uq_params_this_material = it->second;
-      uq_model.ParseBlockInput( uq_params_this_material, block_id, blocks[block_id] );
+      std::string const & nominal_params_string = parser->GetMacroscaleMaterialParameters(block_id);
+      bool block_id_present = std::find(block_ids.begin(), block_ids.end(), block_id) != block_ids.end() ;
+      uq_model.ParseBlockInput( uq_params_this_material, block_id, nominal_params_string, *material_factory, block_id_present, blocks[block_id] );
     }
     // initialize
     uq_model.Initialize(mesh,macroscale_data);


### PR DESCRIPTION
The UQ interface needs to parse material params of all blocks, even those that do not belong to the current mpi rank. To that end, would be easier to have a standalone helper function in material factory that parses and returns the material params string given a material key. 