### PR TITLE
Use Trilinos Release 13.01

### DIFF
--- a/.github/workflows/ubuntu-trilinos-mpi.yml
+++ b/.github/workflows/ubuntu-trilinos-mpi.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         git clone https://github.com/trilinos/Trilinos.git
         cd Trilinos
+        git checkout 4796b92
         mkdir build && cd build
         cmake -DCMAKE_INSTALL_PREFIX="/usr/" \
               -DTPL_ENABLE_MPI=ON \


### PR DESCRIPTION
Closes #146 

Specify the release 13.01 for Trilinos (released on Nov 16, 2020).