### PR TITLE
Rename executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,16 +118,16 @@ IF(NIMBLE_HAVE_KOKKOS)
   )
 ENDIF()
 
-add_executable(nimble.exe nimble.cc)
-target_link_libraries(nimble.exe PRIVATE nimble::nimble)
+add_executable(NimbleSM nimble.cc)
+target_link_libraries(NimbleSM PRIVATE nimble::nimble)
 
 IF(NIMBLE_HAVE_KOKKOS)
   IF (NIMBLE_HAVE_ARBORX)
-    target_link_libraries(nimble.exe PRIVATE ArborX::ArborX)
+    target_link_libraries(NimbleSM PRIVATE ArborX::ArborX)
   ENDIF()
 
   if (NIMBLE_HAVE_TRILINOS OR NIMBLE_HAVE_MPI)
-    target_link_libraries(nimble.exe PRIVATE MPI::MPI_CXX)
+    target_link_libraries(NimbleSM PRIVATE MPI::MPI_CXX)
   ENDIF()
 ENDIF()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Define common variables
 #
 
-set(exe_loc ${CMAKE_BINARY_DIR}/src/nimble.exe)
+set(exe_loc ${CMAKE_BINARY_DIR}/src/NimbleSM)
 
 set(nimble_exe ${exe_loc})
 set(nimble_exe_cli_arg "")


### PR DESCRIPTION
Closes #203 

- Rename `nimble.exe` into `NimbleSM`
   * to avoid `exe` suffix
   * to avoid conflicting name with `libnimble.a`