### PR TITLE
223 Remove redundant code

### DIFF
--- a/src/nimble_kokkos_block_material_interface.cc
+++ b/src/nimble_kokkos_block_material_interface.cc
@@ -66,12 +66,9 @@ compute_block_stress(
   const int stress_len = 6;
   Kokkos::parallel_for(
       "Stress", mdpolicy_2d, KOKKOS_LAMBDA(const int i_elem, const int i_ipt) {
-        nimble::Viewify<1, const double> element_deformation_gradient_step_n_d
-            (Kokkos::subview(deformation_gradient_step_n_d, i_elem, i_ipt, Kokkos::ALL()).data(), def_grad_len);
-        nimble::Viewify<1, const double> element_deformation_gradient_step_np1_d
-            (Kokkos::subview(deformation_gradient_step_np1_d, i_elem, i_ipt, Kokkos::ALL()).data(), def_grad_len);
-        nimble::Viewify<1, const double> element_stress_step_n_d
-            (Kokkos::subview(stress_step_n_d, i_elem, i_ipt, Kokkos::ALL()).data(), stress_len);
+        auto element_deformation_gradient_step_n_d = Kokkos::subview(deformation_gradient_step_n_d, i_elem, i_ipt, Kokkos::ALL());
+        auto element_deformation_gradient_step_np1_d = Kokkos::subview(deformation_gradient_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
+        auto element_stress_step_n_d = Kokkos::subview(stress_step_n_d, i_elem, i_ipt, Kokkos::ALL());
         auto element_stress_step_np1_d = Kokkos::subview(stress_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
         material_device->GetStress(
             time_n,
@@ -79,7 +76,7 @@ compute_block_stress(
             element_deformation_gradient_step_n_d,
             element_deformation_gradient_step_np1_d,
             element_stress_step_n_d,
-            {element_stress_step_np1_d.data(), stress_len});
+            element_stress_step_np1_d);
       });
 }
 

--- a/src/nimble_kokkos_block_material_interface.cc
+++ b/src/nimble_kokkos_block_material_interface.cc
@@ -53,22 +53,25 @@ namespace {
 inline void
 compute_block_stress(
     const nimble::BlockData&                 block_data,
-    nimble_kokkos::DeviceFullTensorIntPtView deformation_gradient_step_n_d,
-    nimble_kokkos::DeviceFullTensorIntPtView deformation_gradient_step_np1_d,
-    nimble_kokkos::DeviceSymTensorIntPtView  stress_step_n_d,
+    const nimble_kokkos::DeviceFullTensorIntPtView &deformation_gradient_step_n_d,
+    const nimble_kokkos::DeviceFullTensorIntPtView &deformation_gradient_step_np1_d,
+    const nimble_kokkos::DeviceSymTensorIntPtView  &stress_step_n_d,
     nimble_kokkos::DeviceSymTensorIntPtView  stress_step_np1_d,
     const double                             time_n,
     const double                             time_np1)
 {
   auto material_device = block_data.material_device;
   auto mdpolicy_2d     = make_elem_point_range_policy(block_data.num_elems, block_data.num_points_per_elem);
+  const int def_grad_len = 9;
+  const int stress_len = 6;
   Kokkos::parallel_for(
       "Stress", mdpolicy_2d, KOKKOS_LAMBDA(const int i_elem, const int i_ipt) {
-        auto element_deformation_gradient_step_n_d =
-            Kokkos::subview(deformation_gradient_step_n_d, i_elem, i_ipt, Kokkos::ALL());
-        auto element_deformation_gradient_step_np1_d =
-            Kokkos::subview(deformation_gradient_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
-        auto element_stress_step_n_d   = Kokkos::subview(stress_step_n_d, i_elem, i_ipt, Kokkos::ALL());
+        nimble::Viewify<1, const double> element_deformation_gradient_step_n_d
+            (Kokkos::subview(deformation_gradient_step_n_d, i_elem, i_ipt, Kokkos::ALL()).data(), def_grad_len);
+        nimble::Viewify<1, const double> element_deformation_gradient_step_np1_d
+            (Kokkos::subview(deformation_gradient_step_np1_d, i_elem, i_ipt, Kokkos::ALL()).data(), def_grad_len);
+        nimble::Viewify<1, const double> element_stress_step_n_d
+            (Kokkos::subview(stress_step_n_d, i_elem, i_ipt, Kokkos::ALL()).data(), stress_len);
         auto element_stress_step_np1_d = Kokkos::subview(stress_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
         material_device->GetStress(
             time_n,
@@ -76,7 +79,7 @@ compute_block_stress(
             element_deformation_gradient_step_n_d,
             element_deformation_gradient_step_np1_d,
             element_stress_step_n_d,
-            element_stress_step_np1_d);
+            {element_stress_step_np1_d.data(), stress_len});
       });
 }
 

--- a/src/nimble_material.cc
+++ b/src/nimble_material.cc
@@ -83,11 +83,11 @@ ElasticMaterial::GetStress(
   double*       stress   = stress_np1;
   const double* def_grad = deformation_gradient_np1;
 
-  nimble::Viewify<1, const double> null_view(nullptr, 0);
+  nimble::Viewify<1, const double> null_view;
 
   for (int pt = 0; pt < num_pts; pt++, def_grad += 9, stress += 6) {
     nimble::Viewify<1, const double> def_grap_np1(def_grad, 9);
-    GetStress(time_previous, time_current, null_view, def_grap_np1, null_view, {stress, {6}, {1}});
+    GetStress(time_previous, time_current, null_view, def_grap_np1, null_view, {stress, 6});
   }
   // TODO rotate stress?
 }
@@ -143,7 +143,7 @@ ElasticMaterial::GetOffNominalStress(
 
   // Cauchy stress
   double*            sig = stress_np1;
-  nimble::Viewify<1, const double> null_view(nullptr, 0);
+  nimble::Viewify<1, const double> null_view;
 
   for (int pt = 0; pt < num_pts; pt++) {
     nimble::Viewify<1, const double> def_grad_view(&deformation_gradient_np1[9 * pt], 9);
@@ -242,7 +242,7 @@ NeohookeanMaterial::GetStress(
   // Cauchy stress
   double* sig = stress_np1;
 
-  nimble::Viewify<1, const double> null_view(nullptr, 0);
+  nimble::Viewify<1, const double> null_view;
   for (int pt = 0; pt < num_pts; pt++) {
     nimble::Viewify<1, const double> def_grad(&deformation_gradient_np1[9 * pt], 9);
     GetStress(time_previous, time_current, null_view, def_grad, null_view, {sig, 6});
@@ -328,7 +328,7 @@ NeohookeanMaterial::GetOffNominalStress(
 
   // Cauchy stress
   double*            sig = stress_np1;
-  nimble::Viewify<1, const double> null_view(nullptr, 0);
+  nimble::Viewify<1, const double> null_view;
 
   for (int pt = 0; pt < num_pts; pt++) {
     nimble::Viewify<1, const double> def_grad_view(&deformation_gradient_np1[9 * pt], 9);

--- a/src/nimble_material.cc
+++ b/src/nimble_material.cc
@@ -67,45 +67,62 @@ ElasticMaterial::ElasticMaterial(MaterialParameters const& material_parameters)
 
 void
 ElasticMaterial::GetStress(
-    int                 elem_id,
-    int                 num_pts,
-    double              time_previous,
-    double              time_current,
-    const double* const deformation_gradient_n,
-    const double* const deformation_gradient_np1,
-    const double* const stress_n,
-    double*             stress_np1,
-    const double* const state_data_n,
-    double*             state_data_np1,
-    DataManager&        data_manager,
-    bool                is_output_step)
+    int           elem_id,
+    int           num_pts,
+    double        time_previous,
+    double        time_current,
+    const double* deformation_gradient_n,
+    const double* deformation_gradient_np1,
+    const double* stress_n,
+    double*       stress_np1,
+    const double* state_data_n,
+    double*       state_data_np1,
+    DataManager&  data_manager,
+    bool          is_output_step)
 {
   double*       stress   = stress_np1;
   const double* def_grad = deformation_gradient_np1;
-  double        strain[6];
-  double        trace_strain;
+
+  nimble::Viewify<1, const double> null_view(nullptr, 0);
+
+  for (int pt = 0; pt < num_pts; pt++, def_grad += 9, stress += 6) {
+    nimble::Viewify<1, const double> def_grap_np1(def_grad, 9);
+    GetStress(time_previous, time_current, null_view, def_grap_np1, null_view, {stress, {6}, {1}});
+  }
+  // TODO rotate stress?
+}
+
+void
+ElasticMaterial::GetStress(
+    double                    time_previous,
+    double                    time_current,
+    nimble::Viewify<1, const double>& deformation_gradient_n,
+    nimble::Viewify<1, const double>& deformation_gradient_np1,
+    nimble::Viewify<1, const double>& stress_n,
+    nimble::Viewify<1>        stress_np1) const
+{
+  auto   def_grad = deformation_gradient_np1.data();
+  double strain[6];
+  double trace_strain;
 
   double two_mu = 2.0 * shear_modulus_;
   double lambda = bulk_modulus_ - 2.0 * shear_modulus_ / 3.0;
 
-  for (int pt = 0; pt < num_pts; pt++, def_grad += 9, stress += 6) {
-    strain[K_S_XX] = def_grad[K_F_XX] - 1.0;
-    strain[K_S_YY] = def_grad[K_F_YY] - 1.0;
-    strain[K_S_ZZ] = def_grad[K_F_ZZ] - 1.0;
-    strain[K_S_XY] = 0.5 * (def_grad[K_F_XY] + def_grad[K_F_YX]);
-    strain[K_S_YZ] = 0.5 * (def_grad[K_F_YZ] + def_grad[K_F_ZY]);
-    strain[K_S_ZX] = 0.5 * (def_grad[K_F_ZX] + def_grad[K_F_XZ]);
+  strain[K_S_XX] = def_grad[K_F_XX] - 1.0;
+  strain[K_S_YY] = def_grad[K_F_YY] - 1.0;
+  strain[K_S_ZZ] = def_grad[K_F_ZZ] - 1.0;
+  strain[K_S_XY] = 0.5 * (def_grad[K_F_XY] + def_grad[K_F_YX]);
+  strain[K_S_YZ] = 0.5 * (def_grad[K_F_YZ] + def_grad[K_F_ZY]);
+  strain[K_S_ZX] = 0.5 * (def_grad[K_F_ZX] + def_grad[K_F_XZ]);
 
-    trace_strain = strain[K_S_XX] + strain[K_S_YY] + strain[K_S_ZZ];
+  trace_strain = strain[K_S_XX] + strain[K_S_YY] + strain[K_S_ZZ];
 
-    stress[K_S_XX] = two_mu * strain[K_S_XX] + lambda * trace_strain;
-    stress[K_S_YY] = two_mu * strain[K_S_YY] + lambda * trace_strain;
-    stress[K_S_ZZ] = two_mu * strain[K_S_ZZ] + lambda * trace_strain;
-    stress[K_S_XY] = two_mu * strain[K_S_XY];
-    stress[K_S_YZ] = two_mu * strain[K_S_YZ];
-    stress[K_S_ZX] = two_mu * strain[K_S_ZX];
-  }
-  // TODO rotate stress?
+  stress_np1(K_S_XX) = two_mu * strain[K_S_XX] + lambda * trace_strain;
+  stress_np1(K_S_YY) = two_mu * strain[K_S_YY] + lambda * trace_strain;
+  stress_np1(K_S_ZZ) = two_mu * strain[K_S_ZZ] + lambda * trace_strain;
+  stress_np1(K_S_XY) = two_mu * strain[K_S_XY];
+  stress_np1(K_S_YZ) = two_mu * strain[K_S_YZ];
+  stress_np1(K_S_ZX) = two_mu * strain[K_S_ZX];
 }
 
 #ifdef NIMBLE_HAVE_UQ
@@ -117,31 +134,27 @@ ElasticMaterial::GetOffNominalStress(
     const double* const deformation_gradient_np1,
     double*             stress_np1)
 {
-  double*       stress   = stress_np1;
-  const double* def_grad = deformation_gradient_np1;
-  double        strain[6];
-  double        trace_strain;
+  //--- Copy current values for bulk and shear moduli
+  double old_bulk = bulk_modulus_;
+  double old_shear = shear_modulus_;
 
-  double two_mu = 2.0 * shear_mod;
-  double lambda = bulk_mod - 2.0 * shear_mod / 3.0;
+  bulk_modulus_ = bulk_mod;
+  shear_modulus_ = shear_mod;
 
-  for (int pt = 0; pt < num_pts; pt++, def_grad += 9, stress += 6) {
-    strain[K_S_XX] = def_grad[K_F_XX] - 1.0;
-    strain[K_S_YY] = def_grad[K_F_YY] - 1.0;
-    strain[K_S_ZZ] = def_grad[K_F_ZZ] - 1.0;
-    strain[K_S_XY] = 0.5 * (def_grad[K_F_XY] + def_grad[K_F_YX]);
-    strain[K_S_YZ] = 0.5 * (def_grad[K_F_YZ] + def_grad[K_F_ZY]);
-    strain[K_S_ZX] = 0.5 * (def_grad[K_F_ZX] + def_grad[K_F_XZ]);
+  // Cauchy stress
+  double*            sig = stress_np1;
+  nimble::Viewify<1, const double> null_view(nullptr, 0);
 
-    trace_strain = strain[K_S_XX] + strain[K_S_YY] + strain[K_S_ZZ];
-
-    stress[K_S_XX] = two_mu * strain[K_S_XX] + lambda * trace_strain;
-    stress[K_S_YY] = two_mu * strain[K_S_YY] + lambda * trace_strain;
-    stress[K_S_ZZ] = two_mu * strain[K_S_ZZ] + lambda * trace_strain;
-    stress[K_S_XY] = two_mu * strain[K_S_XY];
-    stress[K_S_YZ] = two_mu * strain[K_S_YZ];
-    stress[K_S_ZX] = two_mu * strain[K_S_ZX];
+  for (int pt = 0; pt < num_pts; pt++) {
+    nimble::Viewify<1, const double> def_grad_view(&deformation_gradient_np1[9 * pt], 9);
+    GetStress(0.0, 0.0, null_view, def_grad_view, null_view, {sig, 6});
+    sig += 6;
   }
+
+  //--- Reset bulk and shear moduli
+  bulk_modulus_ = old_bulk;
+  shear_modulus_ = old_shear;
+
 }
 #endif
 
@@ -226,131 +239,107 @@ NeohookeanMaterial::GetStress(
     DataManager&        data_manager,
     bool                is_output_step)
 {
-  double xj, fac, pressure, bxx, byy, bzz, bxy, byz, bzx, trace;
-  double sxx, syy, szz, sxy, syz, szx, syx, szy, sxz;
-
-  // left stretch and rotation
-  double v[6], r[9];
   // Cauchy stress
   double* sig = stress_np1;
 
+  nimble::Viewify<1, const double> null_view(nullptr, 0);
   for (int pt = 0; pt < num_pts; pt++) {
-    Polar_Decomp(&deformation_gradient_np1[9 * pt], v, r);
-
-    CheckVectorSanity(9, &deformation_gradient_np1[9 * pt], "neohookean deformation_gradient_np1");
-    CheckVectorSanity(6, v, "neohookean v");
-    CheckVectorSanity(9, r, "neohookean r");
-
-    xj = v[K_S_XX] * v[K_S_YY] * v[K_S_ZZ] + 2.0 * v[K_S_XY] * v[K_S_YZ] * v[K_S_ZX] -
-         v[K_S_XX] * v[K_S_YZ] * v[K_S_YZ] - v[K_S_YY] * v[K_S_ZX] * v[K_S_ZX] - v[K_S_ZZ] * v[K_S_XY] * v[K_S_XY];
-
-    double cbrt_xj = std::cbrt(xj);
-    fac            = 1.0 / (cbrt_xj * cbrt_xj);
-
-    pressure = 0.5 * bulk_modulus_ * (xj - 1.0 / xj);
-
-    bxx = v[K_S_XX] * v[K_S_XX] + v[K_S_XY] * v[K_S_YX] + v[K_S_XZ] * v[K_S_ZX];
-
-    byy = v[K_S_YX] * v[K_S_XY] + v[K_S_YY] * v[K_S_YY] + v[K_S_YZ] * v[K_S_ZY];
-
-    bzz = v[K_S_ZX] * v[K_S_XZ] + v[K_S_ZY] * v[K_S_YZ] + v[K_S_ZZ] * v[K_S_ZZ];
-
-    bxy = v[K_S_XX] * v[K_S_XY] + v[K_S_XY] * v[K_S_YY] + v[K_S_XZ] * v[K_S_ZY];
-
-    byz = v[K_S_YX] * v[K_S_XZ] + v[K_S_YY] * v[K_S_YZ] + v[K_S_YZ] * v[K_S_ZZ];
-
-    bzx = v[K_S_ZX] * v[K_S_XX] + v[K_S_ZY] * v[K_S_YX] + v[K_S_ZZ] * v[K_S_ZX];
-
-    bxx = fac * bxx;
-    byy = fac * byy;
-    bzz = fac * bzz;
-    bxy = fac * bxy;
-    byz = fac * byz;
-    bzx = fac * bzx;
-
-    trace = bxx + byy + bzz;
-
-    bxx = bxx - trace / 3.0;
-    byy = byy - trace / 3.0;
-    bzz = bzz - trace / 3.0;
-
-    sig[K_S_XX] = pressure + shear_modulus_ * bxx / xj;
-    sig[K_S_YY] = pressure + shear_modulus_ * byy / xj;
-    sig[K_S_ZZ] = pressure + shear_modulus_ * bzz / xj;
-    sig[K_S_XY] = shear_modulus_ * bxy / xj;
-    sig[K_S_YZ] = shear_modulus_ * byz / xj;
-    sig[K_S_ZX] = shear_modulus_ * bzx / xj;
-
+    nimble::Viewify<1, const double> def_grad(&deformation_gradient_np1[9 * pt], 9);
+    GetStress(time_previous, time_current, null_view, def_grad, null_view, {sig, 6});
     sig += 6;
   }
+}
+
+void
+NeohookeanMaterial::GetStress(
+    double                    time_previous,
+    double                    time_current,
+    nimble::Viewify<1, const double>& deformation_gradient_n,
+    nimble::Viewify<1, const double>& deformation_gradient_np1,
+    nimble::Viewify<1, const double>& stress_n,
+    nimble::Viewify<1>        stress_np1) const
+{
+  double xj, fac, pressure, bxx, byy, bzz, bxy, byz, bzx, trace;
+
+  // left stretch and rotation
+  double v[6], r[9];
+  Polar_Decomp(deformation_gradient_np1.data(), v, r);
+
+  CheckVectorSanity(9, deformation_gradient_np1.data(), "neohookean deformation_gradient_np1");
+  CheckVectorSanity(6, v, "neohookean v");
+  CheckVectorSanity(9, r, "neohookean r");
+
+  xj = v[K_S_XX] * v[K_S_YY] * v[K_S_ZZ] + 2.0 * v[K_S_XY] * v[K_S_YZ] * v[K_S_ZX] - v[K_S_XX] * v[K_S_YZ] * v[K_S_YZ] -
+       v[K_S_YY] * v[K_S_ZX] * v[K_S_ZX] - v[K_S_ZZ] * v[K_S_XY] * v[K_S_XY];
+
+  double cbrt_xj = std::cbrt(xj);
+  fac            = 1.0 / (cbrt_xj * cbrt_xj);
+
+  pressure = 0.5 * bulk_modulus_ * (xj - 1.0 / xj);
+
+  bxx = v[K_S_XX] * v[K_S_XX] + v[K_S_XY] * v[K_S_YX] + v[K_S_XZ] * v[K_S_ZX];
+
+  byy = v[K_S_YX] * v[K_S_XY] + v[K_S_YY] * v[K_S_YY] + v[K_S_YZ] * v[K_S_ZY];
+
+  bzz = v[K_S_ZX] * v[K_S_XZ] + v[K_S_ZY] * v[K_S_YZ] + v[K_S_ZZ] * v[K_S_ZZ];
+
+  bxy = v[K_S_XX] * v[K_S_XY] + v[K_S_XY] * v[K_S_YY] + v[K_S_XZ] * v[K_S_ZY];
+
+  byz = v[K_S_YX] * v[K_S_XZ] + v[K_S_YY] * v[K_S_YZ] + v[K_S_YZ] * v[K_S_ZZ];
+
+  bzx = v[K_S_ZX] * v[K_S_XX] + v[K_S_ZY] * v[K_S_YX] + v[K_S_ZZ] * v[K_S_ZX];
+
+  bxx = fac * bxx;
+  byy = fac * byy;
+  bzz = fac * bzz;
+  bxy = fac * bxy;
+  byz = fac * byz;
+  bzx = fac * bzx;
+
+  trace = bxx + byy + bzz;
+
+  bxx = bxx - trace / 3.0;
+  byy = byy - trace / 3.0;
+  bzz = bzz - trace / 3.0;
+
+  stress_np1(K_S_XX) = pressure + shear_modulus_ * bxx / xj;
+  stress_np1(K_S_YY) = pressure + shear_modulus_ * byy / xj;
+  stress_np1(K_S_ZZ) = pressure + shear_modulus_ * bzz / xj;
+  stress_np1(K_S_XY) = shear_modulus_ * bxy / xj;
+  stress_np1(K_S_YZ) = shear_modulus_ * byz / xj;
+  stress_np1(K_S_ZX) = shear_modulus_ * bzx / xj;
 }
 
 #ifdef NIMBLE_HAVE_UQ
 void
 NeohookeanMaterial::GetOffNominalStress(
-    const double&       bulk_mod,
-    const double&       shear_mod,
-    int                 num_pts,
-    const double* const deformation_gradient_np1,
-    double*             stress_np1)
+    const double& bulk_mod,
+    const double& shear_mod,
+    int           num_pts,
+    const double* deformation_gradient_np1,
+    double*       stress_np1)
 {
-  double xj, fac, pressure, bxx, byy, bzz, bxy, byz, bzx, trace;
-  double sxx, syy, szz, sxy, syz, szx, syx, szy, sxz;
+  //--- Copy current values for bulk and shear moduli
+  double old_bulk = bulk_modulus_;
+  double old_shear = shear_modulus_;
 
-  // left stretch and rotation
-  double v[6], r[9];
+  bulk_modulus_ = bulk_mod;
+  shear_modulus_ = shear_mod;
+
   // Cauchy stress
-  double* sig = stress_np1;
+  double*            sig = stress_np1;
+  nimble::Viewify<1, const double> null_view(nullptr, 0);
 
   for (int pt = 0; pt < num_pts; pt++) {
-    Polar_Decomp(&deformation_gradient_np1[9 * pt], v, r);
-
-    CheckVectorSanity(9, &deformation_gradient_np1[9 * pt], "neohookean deformation_gradient_np1");
-    CheckVectorSanity(6, v, "neohookean v");
-    CheckVectorSanity(9, r, "neohookean r");
-
-    xj = v[K_S_XX] * v[K_S_YY] * v[K_S_ZZ] + 2.0 * v[K_S_XY] * v[K_S_YZ] * v[K_S_ZX] -
-         v[K_S_XX] * v[K_S_YZ] * v[K_S_YZ] - v[K_S_YY] * v[K_S_ZX] * v[K_S_ZX] - v[K_S_ZZ] * v[K_S_XY] * v[K_S_XY];
-
-    double cbrt_xj = std::cbrt(xj);
-    fac            = 1.0 / (cbrt_xj * cbrt_xj);
-
-    pressure = 0.5 * bulk_mod * (xj - 1.0 / xj);
-
-    bxx = v[K_S_XX] * v[K_S_XX] + v[K_S_XY] * v[K_S_YX] + v[K_S_XZ] * v[K_S_ZX];
-
-    byy = v[K_S_YX] * v[K_S_XY] + v[K_S_YY] * v[K_S_YY] + v[K_S_YZ] * v[K_S_ZY];
-
-    bzz = v[K_S_ZX] * v[K_S_XZ] + v[K_S_ZY] * v[K_S_YZ] + v[K_S_ZZ] * v[K_S_ZZ];
-
-    bxy = v[K_S_XX] * v[K_S_XY] + v[K_S_XY] * v[K_S_YY] + v[K_S_XZ] * v[K_S_ZY];
-
-    byz = v[K_S_YX] * v[K_S_XZ] + v[K_S_YY] * v[K_S_YZ] + v[K_S_YZ] * v[K_S_ZZ];
-
-    bzx = v[K_S_ZX] * v[K_S_XX] + v[K_S_ZY] * v[K_S_YX] + v[K_S_ZZ] * v[K_S_ZX];
-
-    bxx = fac * bxx;
-    byy = fac * byy;
-    bzz = fac * bzz;
-    bxy = fac * bxy;
-    byz = fac * byz;
-    bzx = fac * bzx;
-
-    trace = bxx + byy + bzz;
-
-    bxx = bxx - trace / 3.0;
-    byy = byy - trace / 3.0;
-    bzz = bzz - trace / 3.0;
-
-    sig[K_S_XX] = pressure + shear_mod * bxx / xj;
-    sig[K_S_YY] = pressure + shear_mod * byy / xj;
-    sig[K_S_ZZ] = pressure + shear_mod * bzz / xj;
-    sig[K_S_XY] = shear_mod * bxy / xj;
-    sig[K_S_YZ] = shear_mod * byz / xj;
-    sig[K_S_ZX] = shear_mod * bzx / xj;
-
+    nimble::Viewify<1, const double> def_grad_view(&deformation_gradient_np1[9 * pt], 9);
+    GetStress(0.0, 0.0, null_view, def_grad_view, null_view, {sig, 6});
     sig += 6;
   }
+
+  //--- Reset bulk and shear moduli
+  bulk_modulus_ = old_bulk;
+  shear_modulus_ = old_shear;
+
 }
 #endif
 

--- a/src/nimble_material.h
+++ b/src/nimble_material.h
@@ -50,38 +50,13 @@
 #include "nimble_data_utils.h"
 #include "nimble_defs.h"
 #include "nimble_utils.h"
+#include "nimble_view.h"
 
 namespace nimble {
 
 class DataManager;
 class MaterialFactoryBase;
 class MaterialFactory;
-
-NIMBLE_INLINE_FUNCTION
-int
-StringLength(const char* str)
-{
-  int len = 0;
-  while (str[len] != '\0') { len++; }
-  return len;
-}
-
-NIMBLE_INLINE_FUNCTION
-bool
-StringsAreEqual(const char* str1, const char* str2)
-{
-  int  len1      = StringLength(str1);
-  int  len2      = StringLength(str2);
-  int  len       = len1 < len2 ? len1 : len2;
-  bool are_equal = true;
-  for (int i = 0; i < len; ++i) {
-    if (str1[i] != str2[i]) {
-      are_equal = false;
-      break;
-    }
-  }
-  return are_equal;
-}
 
 class MaterialParameters
 {
@@ -110,7 +85,7 @@ class MaterialParameters
     std::transform(s.begin(), s.end(), s.begin(), ::toupper);
   }
 
-  inline ~MaterialParameters() {}
+  inline ~MaterialParameters() = default;
 
   inline void
   AddParameter(const char* parameter_name, double parameter_value)
@@ -147,13 +122,13 @@ class MaterialParameters
   inline int
   GetNumParameters() const
   {
-    return material_double_parameters_.size();
+    return static_cast<int>(material_double_parameters_.size());
   }
 
   inline int
   GetNumStringParameters() const
   {
-    return material_string_parameters_.size();
+    return static_cast<int>(material_string_parameters_.size());
   }
 
   inline double
@@ -201,12 +176,12 @@ class MaterialParameters
   {
     printf("\n--MaterialParameters\n");
     printf("  material name %s\n", material_name_.c_str());
-    int num_material_double_parameters_ = material_double_parameters_.size();
+    int num_material_double_parameters_ = static_cast<int>(material_double_parameters_.size());
     printf("  number of material double parameters %d\n", num_material_double_parameters_);
-    for (auto p : material_double_parameters_) { printf("  %s %f\n", p.first.c_str(), p.second); }
-    int num_material_string_parameters_ = material_string_parameters_.size();
+    for (const auto& p : material_double_parameters_) { printf("  %s %f\n", p.first.c_str(), p.second); }
+    int num_material_string_parameters_ = static_cast<int>(material_string_parameters_.size());
     printf("  number of material string parameters %d\n", num_material_string_parameters_);
-    for (auto p : material_string_parameters_) { printf("  %s %s\n", p.first.c_str(), p.second.c_str()); }
+    for (const auto& p : material_string_parameters_) { printf("  %s %s\n", p.first.c_str(), p.second.c_str()); }
   }
 
  private:
@@ -222,13 +197,13 @@ class Material
 {
  public:
   NIMBLE_FUNCTION
-  Material() {}
+  Material() = default;
 
   NIMBLE_FUNCTION
   Material(const Material& mat) = default;
 
   NIMBLE_FUNCTION
-  virtual ~Material() {}
+  virtual ~Material() = default;
 
   NIMBLE_FUNCTION
   virtual bool
@@ -275,30 +250,29 @@ class Material
   NIMBLE_FUNCTION
   virtual void
   GetStress(
-      int                 elem_id,
-      int                 num_pts,
-      double              time_previous,
-      double              time_current,
-      const double* const deformation_gradient_n,
-      const double* const deformation_gradient_np1,
-      const double* const stress_n,
-      double*             stress_np1,
-      const double* const state_data_n,
-      double*             state_data_np1,
-      DataManager&        data_manager,
-      bool                is_output_step) = 0;
+      int           elem_id,
+      int           num_pts,
+      double        time_previous,
+      double        time_current,
+      const double* deformation_gradient_n,
+      const double* deformation_gradient_np1,
+      const double* stress_n,
+      double*       stress_np1,
+      const double* state_data_n,
+      double*       state_data_np1,
+      DataManager&  data_manager,
+      bool          is_output_step) = 0;
 
-#ifdef NIMBLE_HAVE_KOKKOS
   NIMBLE_FUNCTION
   virtual void
   GetStress(
-      double                                              time_previous,
-      double                                              time_current,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_n,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_np1,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_n,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1) = 0;
-#endif
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const = 0;
+
   NIMBLE_FUNCTION
   virtual void
   GetTangent(int num_pts, double* material_tangent) const = 0;
@@ -307,33 +281,13 @@ class Material
   NIMBLE_FUNCTION
   virtual void
   GetOffNominalStress(
-      const double&       bulk_mod,
-      const double&       shear_mod,
-      int                 num_pts,
-      const double* const deformation_gradient_np1,
-      double*             stress_np1) = 0;
+      const double& bulk_mod,
+      const double& shear_mod,
+      int           num_pts,
+      const double* deformation_gradient_np1,
+      double*       stress_np1) = 0;
 #endif
 
- protected:
-  const int K_S_XX_ = 0;
-  const int K_S_YY_ = 1;
-  const int K_S_ZZ_ = 2;
-  const int K_S_XY_ = 3;
-  const int K_S_YZ_ = 4;
-  const int K_S_ZX_ = 5;
-  const int K_S_YX_ = 3;
-  const int K_S_ZY_ = 4;
-  const int K_S_XZ_ = 5;
-
-  const int K_F_XX_ = 0;
-  const int K_F_YY_ = 1;
-  const int K_F_ZZ_ = 2;
-  const int K_F_XY_ = 3;
-  const int K_F_YZ_ = 4;
-  const int K_F_ZX_ = 5;
-  const int K_F_YX_ = 6;
-  const int K_F_ZY_ = 7;
-  const int K_F_XZ_ = 8;
 };
 
 class ElasticMaterial : public Material
@@ -398,30 +352,28 @@ class ElasticMaterial : public Material
   NIMBLE_FUNCTION
   void
   GetStress(
-      int                 elem_id,
-      int                 num_pts,
-      double              time_previous,
-      double              time_current,
-      const double* const deformation_gradient_n,
-      const double* const deformation_gradient_np1,
-      const double* const stress_n,
-      double*             stress_np1,
-      const double* const state_data_n,
-      double*             state_data_np1,
-      DataManager&        data_manager,
-      bool                is_output_step) override;
+      int           elem_id,
+      int           num_pts,
+      double        time_previous,
+      double        time_current,
+      const double* deformation_gradient_n,
+      const double* deformation_gradient_np1,
+      const double* stress_n,
+      double*       stress_np1,
+      const double* state_data_n,
+      double*       state_data_np1,
+      DataManager&  data_manager,
+      bool          is_output_step) override;
 
-#ifdef NIMBLE_HAVE_KOKKOS
-  NIMBLE_INLINE_FUNCTION
+  NIMBLE_FUNCTION
   void
   GetStress(
-      double                                              time_previous,
-      double                                              time_current,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_n,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_np1,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_n,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1) override;
-#endif
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
 
   NIMBLE_FUNCTION
   void
@@ -431,11 +383,11 @@ class ElasticMaterial : public Material
   NIMBLE_FUNCTION
   void
   GetOffNominalStress(
-      const double&       bulk_mod,
-      const double&       shear_mod,
-      int                 num_pts,
-      const double* const deformation_gradient_np1,
-      double*             stress_np1) override;
+      const double& bulk_mod,
+      const double& shear_mod,
+      int           num_pts,
+      const double* deformation_gradient_np1,
+      double*       stress_np1) override;
 #endif
 
  private:
@@ -508,30 +460,28 @@ class NeohookeanMaterial : public Material
   NIMBLE_FUNCTION
   void
   GetStress(
-      int                 elem_id,
-      int                 num_pts,
-      double              time_previous,
-      double              time_current,
-      const double* const deformation_gradient_n,
-      const double* const deformation_gradient_np1,
-      const double* const stress_n,
-      double*             stress_np1,
-      const double* const state_data_n,
-      double*             state_data_np1,
-      DataManager&        data_manager,
-      bool                is_output_step) override;
+      int           elem_id,
+      int           num_pts,
+      double        time_previous,
+      double        time_current,
+      const double* deformation_gradient_n,
+      const double* deformation_gradient_np1,
+      const double* stress_n,
+      double*       stress_np1,
+      const double* state_data_n,
+      double*       state_data_np1,
+      DataManager&  data_manager,
+      bool          is_output_step) override;
 
-#ifdef NIMBLE_HAVE_KOKKOS
-  NIMBLE_INLINE_FUNCTION
+  NIMBLE_FUNCTION
   void
   GetStress(
-      double                                              time_previous,
-      double                                              time_current,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_n,
-      nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_np1,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_n,
-      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1) override;
-#endif
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
 
   NIMBLE_FUNCTION
   void
@@ -541,11 +491,11 @@ class NeohookeanMaterial : public Material
   NIMBLE_FUNCTION
   void
   GetOffNominalStress(
-      const double&       bulk_mod,
-      const double&       shear_mod,
-      int                 num_pts,
-      const double* const deformation_gradient_np1,
-      double*             stress_np1) override;
+      const double& bulk_mod,
+      const double& shear_mod,
+      int           num_pts,
+      const double* deformation_gradient_np1,
+      double*       stress_np1) override;
 #endif
 
  private:
@@ -555,110 +505,6 @@ class NeohookeanMaterial : public Material
   double bulk_modulus_;
   double shear_modulus_;
 };
-
-#ifdef NIMBLE_HAVE_KOKKOS
-NIMBLE_FUNCTION
-void
-ElasticMaterial::GetStress(
-    double                                              time_previous,
-    double                                              time_current,
-    nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_n,
-    nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_np1,
-    nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_n,
-    nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1)
-{
-  nimble_kokkos::DeviceFullTensorIntPtSingleEntryView& def_grad = deformation_gradient_np1;
-  nimble_kokkos::DeviceSymTensorIntPtSingleEntryView&  stress   = stress_np1;
-  double                                               strain[6];
-  double                                               trace_strain;
-
-  double two_mu = 2.0 * shear_modulus_;
-  double lambda = bulk_modulus_ - 2.0 * shear_modulus_ / 3.0;
-
-  strain[K_S_XX_] = def_grad[K_F_XX_] - 1.0;
-  strain[K_S_YY_] = def_grad[K_F_YY_] - 1.0;
-  strain[K_S_ZZ_] = def_grad[K_F_ZZ_] - 1.0;
-  strain[K_S_XY_] = 0.5 * (def_grad[K_F_XY_] + def_grad[K_F_YX_]);
-  strain[K_S_YZ_] = 0.5 * (def_grad[K_F_YZ_] + def_grad[K_F_ZY_]);
-  strain[K_S_ZX_] = 0.5 * (def_grad[K_F_ZX_] + def_grad[K_F_XZ_]);
-
-  trace_strain = strain[K_S_XX_] + strain[K_S_YY_] + strain[K_S_ZZ_];
-
-  stress[K_S_XX_] = two_mu * strain[K_S_XX_] + lambda * trace_strain;
-  stress[K_S_YY_] = two_mu * strain[K_S_YY_] + lambda * trace_strain;
-  stress[K_S_ZZ_] = two_mu * strain[K_S_ZZ_] + lambda * trace_strain;
-  stress[K_S_XY_] = two_mu * strain[K_S_XY_];
-  stress[K_S_YZ_] = two_mu * strain[K_S_YZ_];
-  stress[K_S_ZX_] = two_mu * strain[K_S_ZX_];
-
-  // TODO rotate stress?
-}
-
-NIMBLE_FUNCTION
-void
-NeohookeanMaterial::GetStress(
-    double                                              time_previous,
-    double                                              time_current,
-    nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_n,
-    nimble_kokkos::DeviceFullTensorIntPtSingleEntryView deformation_gradient_np1,
-    nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_n,
-    nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1)
-{
-  double xj, fac, pressure, bxx, byy, bzz, bxy, byz, bzx, trace;
-  double sxx, syy, szz, sxy, syz, szx, syx, szy, sxz;
-
-  // deformation gradient, left stretch, and rotation
-  double def_grad[9], v[6], r[9];
-  for (int i = 0; i < 9; i++) { def_grad[i] = deformation_gradient_np1[i]; }
-
-  Polar_Decomp(def_grad, v, r);
-
-  CheckVectorSanity(9, def_grad, "neohookean deformation_gradient_np1");
-  CheckVectorSanity(6, v, "neohookean v");
-  CheckVectorSanity(9, r, "neohookean r");
-
-  xj = v[K_S_XX_] * v[K_S_YY_] * v[K_S_ZZ_] + 2.0 * v[K_S_XY_] * v[K_S_YZ_] * v[K_S_ZX_] -
-       v[K_S_XX_] * v[K_S_YZ_] * v[K_S_YZ_] - v[K_S_YY_] * v[K_S_ZX_] * v[K_S_ZX_] -
-       v[K_S_ZZ_] * v[K_S_XY_] * v[K_S_XY_];
-
-  double cbrt_xj = std::cbrt(xj);
-  fac            = 1.0 / (cbrt_xj * cbrt_xj);
-
-  pressure = 0.5 * bulk_modulus_ * (xj - 1.0 / xj);
-
-  bxx = v[K_S_XX_] * v[K_S_XX_] + v[K_S_XY_] * v[K_S_YX_] + v[K_S_XZ_] * v[K_S_ZX_];
-
-  byy = v[K_S_YX_] * v[K_S_XY_] + v[K_S_YY_] * v[K_S_YY_] + v[K_S_YZ_] * v[K_S_ZY_];
-
-  bzz = v[K_S_ZX_] * v[K_S_XZ_] + v[K_S_ZY_] * v[K_S_YZ_] + v[K_S_ZZ_] * v[K_S_ZZ_];
-
-  bxy = v[K_S_XX_] * v[K_S_XY_] + v[K_S_XY_] * v[K_S_YY_] + v[K_S_XZ_] * v[K_S_ZY_];
-
-  byz = v[K_S_YX_] * v[K_S_XZ_] + v[K_S_YY_] * v[K_S_YZ_] + v[K_S_YZ_] * v[K_S_ZZ_];
-
-  bzx = v[K_S_ZX_] * v[K_S_XX_] + v[K_S_ZY_] * v[K_S_YX_] + v[K_S_ZZ_] * v[K_S_ZX_];
-
-  bxx = fac * bxx;
-  byy = fac * byy;
-  bzz = fac * bzz;
-  bxy = fac * bxy;
-  byz = fac * byz;
-  bzx = fac * bzx;
-
-  trace = bxx + byy + bzz;
-
-  bxx = bxx - trace / 3.0;
-  byy = byy - trace / 3.0;
-  bzz = bzz - trace / 3.0;
-
-  stress_np1(K_S_XX_) = pressure + shear_modulus_ * bxx / xj;
-  stress_np1(K_S_YY_) = pressure + shear_modulus_ * byy / xj;
-  stress_np1(K_S_ZZ_) = pressure + shear_modulus_ * bzz / xj;
-  stress_np1(K_S_XY_) = shear_modulus_ * bxy / xj;
-  stress_np1(K_S_YZ_) = shear_modulus_ * byz / xj;
-  stress_np1(K_S_ZX_) = shear_modulus_ * bzx / xj;
-}
-#endif
 
 }  // namespace nimble
 

--- a/src/nimble_material.h
+++ b/src/nimble_material.h
@@ -263,15 +263,24 @@ class Material
       DataManager&  data_manager,
       bool          is_output_step) = 0;
 
+#ifdef NIMBLE_HAVE_KOKKOS
   NIMBLE_FUNCTION
   virtual void
   GetStress(
-      double                    time_previous,
-      double                    time_current,
-      nimble::Viewify<1, const double>& deformation_gradient_n,
-      nimble::Viewify<1, const double>& deformation_gradient_np1,
-      nimble::Viewify<1, const double>& stress_n,
-      nimble::Viewify<1>        stress_np1) const = 0;
+      double                                              time_previous,
+      double                                              time_current,
+      const nimble_kokkos::DeviceFullTensorIntPtSingleEntryView &deformation_gradient_n,
+      const nimble_kokkos::DeviceFullTensorIntPtSingleEntryView &deformation_gradient_np1,
+      const nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  &stress_n,
+      nimble_kokkos::DeviceSymTensorIntPtSingleEntryView  stress_np1) const {
+    const int def_g_len = 9, stress_len = 6;
+    nimble::Viewify<1, const double> def_g_n(deformation_gradient_n.data(), def_g_len);
+    nimble::Viewify<1, const double> def_g_np1(deformation_gradient_np1.data(), def_g_len);
+    nimble::Viewify<1, const double> s_n(stress_n.data(), stress_len);
+    nimble::Viewify<1> s_np1(stress_np1.data(), stress_len);
+    GetStress(time_previous, time_current, def_g_n, def_g_np1, s_n, s_np1);
+  }
+#endif
 
   NIMBLE_FUNCTION
   virtual void
@@ -287,6 +296,18 @@ class Material
       const double* deformation_gradient_np1,
       double*       stress_np1) = 0;
 #endif
+
+protected:
+
+  NIMBLE_FUNCTION
+  virtual void
+  GetStress(
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const = 0;
 
 };
 
@@ -367,16 +388,6 @@ class ElasticMaterial : public Material
 
   NIMBLE_FUNCTION
   void
-  GetStress(
-      double                    time_previous,
-      double                    time_current,
-      nimble::Viewify<1, const double>& deformation_gradient_n,
-      nimble::Viewify<1, const double>& deformation_gradient_np1,
-      nimble::Viewify<1, const double>& stress_n,
-      nimble::Viewify<1>        stress_np1) const override;
-
-  NIMBLE_FUNCTION
-  void
   GetTangent(int num_pts, double* material_tangent) const override;
 
 #ifdef NIMBLE_HAVE_UQ
@@ -389,6 +400,18 @@ class ElasticMaterial : public Material
       const double* deformation_gradient_np1,
       double*       stress_np1) override;
 #endif
+
+ protected:
+
+  NIMBLE_FUNCTION
+  void
+  GetStress(
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
 
  private:
   int    num_state_variables_;
@@ -475,16 +498,6 @@ class NeohookeanMaterial : public Material
 
   NIMBLE_FUNCTION
   void
-  GetStress(
-      double                    time_previous,
-      double                    time_current,
-      nimble::Viewify<1, const double>& deformation_gradient_n,
-      nimble::Viewify<1, const double>& deformation_gradient_np1,
-      nimble::Viewify<1, const double>& stress_n,
-      nimble::Viewify<1>        stress_np1) const override;
-
-  NIMBLE_FUNCTION
-  void
   GetTangent(int num_pts, double* material_tangent) const override;
 
 #ifdef NIMBLE_HAVE_UQ
@@ -497,6 +510,18 @@ class NeohookeanMaterial : public Material
       const double* deformation_gradient_np1,
       double*       stress_np1) override;
 #endif
+
+ protected:
+
+  NIMBLE_FUNCTION
+  void
+  GetStress(
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
 
  private:
   int    num_state_variables_;

--- a/src/nimble_rve.cc
+++ b/src/nimble_rve.cc
@@ -336,11 +336,11 @@ RVE::GetStress(
     int                 num_pts,
     double              time_previous,
     double              time_current,
-    const double* const deformation_gradient_n,
-    const double* const deformation_gradient_np1,
-    const double* const stress_n,
+    const double* deformation_gradient_n,
+    const double* deformation_gradient_np1,
+    const double* stress_n,
     double*             stress_np1,
-    const double* const state_data_n,
+    const double* state_data_n,
     double*             state_data_np1,
     DataManager&        data_manager,
     bool                is_output_step)
@@ -887,4 +887,17 @@ void
 RVE::GetTangent(int num_pts, double* material_tangent) const
 {
 }
+
+void
+RVE::GetStress(
+    double                    time_previous,
+    double                    time_current,
+    Viewify<1, const double>& deformation_gradient_n,
+    Viewify<1, const double>& deformation_gradient_np1,
+    Viewify<1, const double>& stress_n,
+    nimble::Viewify<1>        stress_np1) const
+{
+  throw std::runtime_error("\n RVE::GetStress Not Implemented \n");
+}
+
 }  // namespace nimble

--- a/src/nimble_rve.h
+++ b/src/nimble_rve.h
@@ -134,16 +134,26 @@ class RVE : public Material
       int                 num_pts,
       double              time_previous,
       double              time_current,
-      const double* const deformation_gradient_n,
-      const double* const deformation_gradient_np1,
-      const double* const stress_n,
+      const double* deformation_gradient_n,
+      const double* deformation_gradient_np1,
+      const double* stress_n,
       double*             stress_np1,
-      const double* const state_data_n,
+      const double* state_data_n,
       double*             state_data_np1,
       DataManager&        data_manager,
       bool                is_output_step) override;
 
-//#ifdef NIMBLE_HAVE_KOKKOS
+  NIMBLE_FUNCTION
+  void
+  GetStress(
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
+
+  //#ifdef NIMBLE_HAVE_KOKKOS
 //  NIMBLE_FUNCTION
 //  void
 //  GetStress(

--- a/src/nimble_rve.h
+++ b/src/nimble_rve.h
@@ -79,7 +79,7 @@ class RVE : public Material
       std::string                       rve_boundary_condition_strategy);
 
   NIMBLE_FUNCTION
-  virtual ~RVE() {}
+  virtual ~RVE() = default;
 
   std::map<std::string, double>
   ParseParametersString(std::string const& material_parameters_string) const;
@@ -145,30 +145,6 @@ class RVE : public Material
 
   NIMBLE_FUNCTION
   void
-  GetStress(
-      double                    time_previous,
-      double                    time_current,
-      nimble::Viewify<1, const double>& deformation_gradient_n,
-      nimble::Viewify<1, const double>& deformation_gradient_np1,
-      nimble::Viewify<1, const double>& stress_n,
-      nimble::Viewify<1>        stress_np1) const override;
-
-  //#ifdef NIMBLE_HAVE_KOKKOS
-//  NIMBLE_FUNCTION
-//  void
-//  GetStress(
-//      double                                         time_previous,
-//      double                                         time_current,
-//      nimble_kokkos::DeviceFullTensorSingleEntryView deformation_gradient_n,
-//      nimble_kokkos::DeviceFullTensorSingleEntryView deformation_gradient_np1,
-//      nimble_kokkos::DeviceSymTensorSingleEntryView  stress_n,
-//      nimble_kokkos::DeviceSymTensorSingleEntryView  stress_np1)
-//  {
-//  }
-//#endif
-
-  NIMBLE_FUNCTION
-  void
   GetTangent(int num_pts, double* material_tangent) const override;
 
 #ifdef NIMBLE_HAVE_UQ
@@ -182,6 +158,18 @@ class RVE : public Material
       double*             stress_np1) override
   {}
 #endif
+
+ protected:
+
+  NIMBLE_FUNCTION
+  void
+  GetStress(
+      double                    time_previous,
+      double                    time_current,
+      nimble::Viewify<1, const double>& deformation_gradient_n,
+      nimble::Viewify<1, const double>& deformation_gradient_np1,
+      nimble::Viewify<1, const double>& stress_n,
+      nimble::Viewify<1>        stress_np1) const override;
 
  private:
   std::map<int, std::string>  material_parameters_string_;

--- a/src/nimble_utils.h
+++ b/src/nimble_utils.h
@@ -52,6 +52,32 @@
 #include <sstream>
 #include <stdexcept>
 
+NIMBLE_INLINE_FUNCTION
+int
+StringLength(const char* str)
+{
+  int len = 0;
+  while (str[len] != '\0') { len++; }
+  return len;
+}
+
+NIMBLE_INLINE_FUNCTION
+bool
+StringsAreEqual(const char* str1, const char* str2)
+{
+  int  len1      = StringLength(str1);
+  int  len2      = StringLength(str2);
+  int  len       = len1 < len2 ? len1 : len2;
+  bool are_equal = true;
+  for (int i = 0; i < len; ++i) {
+    if (str1[i] != str2[i]) {
+      are_equal = false;
+      break;
+    }
+  }
+  return are_equal;
+}
+
 // Need to avoid conflicts with NimbleSMExtras definitions
 #ifndef K_X
 static constexpr int K_X = 0;

--- a/src/nimble_view.h
+++ b/src/nimble_view.h
@@ -67,7 +67,7 @@ class AXPYResult;
 
 }
 
-template <std::size_t N = 2>
+template <std::size_t N = 2, class Scalar = double>
 class Viewify
 {
  public:
@@ -77,34 +77,39 @@ class Viewify
     stride_.fill(0);
   }
 
-  Viewify(double* const data, std::array<int, N> len, std::array<int, N> stride)
+  Viewify(Scalar* const data, std::array<int, N> len, std::array<int, N> stride)
       : data_(data), len_(len), stride_(stride)
   {
   }
 
+  template <std::size_t NN = N, typename X = typename std::enable_if<(NN == 1), void>::type>
+  Viewify(Scalar* const data, int len)
+      : data_(data), len_({len}), stride_({1})
+  { }
+
   template <std::size_t NN = N>
-  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 1), double>::type&
+  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 1), Scalar>::type&
   operator()(int i)
   {
     return data_[i];
   }
 
   template <std::size_t NN = N>
-  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 1), const double>::type
+  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 1), const Scalar>::type
   operator()(int i) const
   {
     return data_[i];
   }
 
   template <std::size_t NN = N>
-  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 2), double>::type&
+  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 2), Scalar>::type&
   operator()(int i, int j)
   {
     return data_[i * stride_[0] + j * stride_[1]];
   }
 
   template <std::size_t NN = N>
-  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 2), const double>::type
+  NIMBLE_INLINE_FUNCTION typename std::enable_if<(NN == 2), const Scalar>::type
   operator()(int i, int j) const
   {
     return data_[i * stride_[0] + j * stride_[1]];
@@ -114,7 +119,7 @@ class Viewify
   zero()
   {
     int mySize = stride_[0] * len_[0];
-    for (int ii = 0; ii < mySize; ++ii) data_[ii] = 0.0;
+    for (int ii = 0; ii < mySize; ++ii) data_[ii] = (Scalar)(0);
   }
 
   void
@@ -124,13 +129,14 @@ class Viewify
     for (int ii = 0; ii < mySize; ++ii) data_[ii] = ref.data_[ii];
   }
 
-  double*
+  Scalar*
   data() const
   {
     return data_;
   }
 
-  Viewify<N>&
+  template< class T = Scalar, typename X = std::enable_if_t< !std::is_const<T>::value > >
+  Viewify<N, Scalar>&
   operator+=(const details::AXPYResult<N>& rhs);
 
   std::array<int, N>
@@ -146,7 +152,7 @@ class Viewify
   }
 
  protected:
-  double*            data_;
+  Scalar*            data_;
   std::array<int, N> len_;
   std::array<int, N> stride_;
 };
@@ -201,9 +207,10 @@ AXPYResult<N>::assignTo(double destCoef, double rhsCoef, nimble::Viewify<N>& des
 
 //----------------------------------
 
-template <std::size_t N>
-Viewify<N>&
-Viewify<N>::operator+=(const details::AXPYResult<N>& rhs)
+template <std::size_t N, class Scalar>
+template <class T, typename X>
+Viewify<N, Scalar>&
+Viewify<N, Scalar>::operator+=(const details::AXPYResult<N>& rhs)
 {
   rhs.assignTo(1.0, 1.0, *this);
   return *this;

--- a/src/nimble_view.h
+++ b/src/nimble_view.h
@@ -77,13 +77,13 @@ class Viewify
     stride_.fill(0);
   }
 
-  Viewify(Scalar* const data, std::array<int, N> len, std::array<int, N> stride)
+  Viewify(Scalar* data, std::array<int, N> len, std::array<int, N> stride)
       : data_(data), len_(len), stride_(stride)
   {
   }
 
-  template <std::size_t NN = N, typename X = typename std::enable_if<(NN == 1), void>::type>
-  Viewify(Scalar* const data, int len)
+  template <std::size_t NN = N, typename = typename std::enable_if<(NN == 1)>::type >
+  Viewify(Scalar* data, int len)
       : data_(data), len_({len}), stride_({1})
   { }
 
@@ -135,7 +135,7 @@ class Viewify
     return data_;
   }
 
-  template< class T = Scalar, typename X = std::enable_if_t< !std::is_const<T>::value > >
+  template< class T = Scalar, typename = typename std::enable_if< !std::is_const<T>::value >::type >
   Viewify<N, Scalar>&
   operator+=(const details::AXPYResult<N>& rhs);
 
@@ -208,7 +208,7 @@ AXPYResult<N>::assignTo(double destCoef, double rhsCoef, nimble::Viewify<N>& des
 //----------------------------------
 
 template <std::size_t N, class Scalar>
-template <class T, typename X>
+template <class T, typename >
 Viewify<N, Scalar>&
 Viewify<N, Scalar>::operator+=(const details::AXPYResult<N>& rhs)
 {


### PR DESCRIPTION
- Use only one instance of computation for stress per material (as opposed to 3). 
- Enhance nimble::Viewify with template scalar (for const values). 
- Move utility routines to nimble_utils.

Closes #223