### PR TITLE
Remove sorting in ArborX

### DIFF
--- a/src/contact/parallel/bvh_contact_manager.cc
+++ b/src/contact/parallel/bvh_contact_manager.cc
@@ -209,7 +209,7 @@ struct NarrowphaseFunc
     //
     std::vector<NarrowphaseResult> resa_vec, resb_vec;
     ArborX::Experimental::TraversalPolicy policy;
-    policy._sort_predicates = false;
+    policy.setPredicateSorting(false);
     //
     a_bvh.query(nimble_kokkos::kokkos_host_execution_space{}, view_b,
                 details::ArborXCallback{view_a, view_b, contact_manager->GetPenaltyForceParam(), resa_vec, resb_vec},

--- a/src/contact/parallel/bvh_contact_manager.cc
+++ b/src/contact/parallel/bvh_contact_manager.cc
@@ -182,12 +182,16 @@ struct NarrowphaseFunc
     ArborX::BVH<memory_space> a_bvh{nimble_kokkos::kokkos_host_execution_space{}, view_a};
     //
     std::vector<NarrowphaseResult> resa_vec, resb_vec;
-    ArborX::Experimental::TraversalPolicy policy;
-    policy.setPredicateSorting(false);
+    //
+    // ArborX has the option to turning off/on a sorting of the predicates (= contact nodes)
+    // It has also the option to provide an estimate of the number of resulting contact to speed up the query.
+    // For these two features, a `TraversalPolicy` variable has to be specified as an input
+    // parameter for the query.
+    //
+    // ArborX::Experimental::TraversalPolicy policy;
     //
     a_bvh.query(nimble_kokkos::kokkos_host_execution_space{}, view_b,
-                details::ArborXCallback{view_a, view_b, contact_manager->GetPenaltyForceParam(), resa_vec, resb_vec},
-                policy);
+                details::ArborXCallback{view_a, view_b, contact_manager->GetPenaltyForceParam(), resa_vec, resb_vec});
     //
     resa.set_data(resa_vec.data(), resa_vec.size());
     resb.set_data(resb_vec.data(), resb_vec.size());

--- a/src/contact/parallel/bvh_contact_manager.cc
+++ b/src/contact/parallel/bvh_contact_manager.cc
@@ -70,9 +70,6 @@ namespace details {
 #ifdef NIMBLE_HAVE_ARBORX
 struct ArborXCallback
 {
-  nimble_kokkos::DeviceContactEntityArrayView d_contact_faces;
-  nimble_kokkos::DeviceContactEntityArrayView d_contact_nodes;
-
   const nimble_kokkos::HostContactEntityUnmanagedConstView &d_contact_faces;
   const nimble_kokkos::HostContactEntityUnmanagedConstView &d_contact_nodes;
 
@@ -181,31 +178,8 @@ struct NarrowphaseFunc
       d_contact_nodes(ii).ResetContactData();
     }
     //
-    Kokkos::View<int*, nimble_kokkos::kokkos_device> indices("indices", 0);
-    Kokkos::View<int*, nimble_kokkos::kokkos_device> offset("offset", 0);
-    //
-    using memory_space = nimble_kokkos::kokkos_device_memory_space;
-    ArborX::BVH<memory_space> a_bvh{nimble_kokkos::kokkos_device_execution_space{}, d_contact_faces};
     using memory_space = nimble_kokkos::kokkos_host_mirror_memory_space;
     ArborX::BVH<memory_space> a_bvh{nimble_kokkos::kokkos_host_execution_space{}, view_a};
-    //
-    // indices : position of the primitives that satisfy the predicates.
-    // offsets : predicate offsets in indices.
-    //
-    // indices stores the indices of the objects that satisfy the predicates.
-    // offset stores the locations in the indices view that start a predicate,
-    // that is, predicates(q) is satisfied by indices(o) for primitives(q) <= o <
-    // primitives(q+1).
-    //
-    // Following the usual convention, offset(n) = nnz, where n is the number of
-    // queries that were performed and nnz is the total number of collisions.
-    //
-    // (From
-    // https://github.com/arborx/ArborX/wiki/ArborX%3A%3ABoundingVolumeHierarchy%3A%3Aquery
-    // )
-    //
-    // Number of queries, n = size of contact_nodes_d
-    // Size of offset = n + 1
     //
     std::vector<NarrowphaseResult> resa_vec, resb_vec;
     ArborX::Experimental::TraversalPolicy policy;

--- a/src/nimble_model_data.cc
+++ b/src/nimble_model_data.cc
@@ -615,8 +615,8 @@ ModelData::ComputeExternalForce(
     double               time_current,
     bool                 is_output_step)
 {
-  auto internal_force = GetVectorNodeData("external_force");
-  internal_force.zero();
+  auto force = GetVectorNodeData("external_force");
+  force.zero();
 }
 
 void


### PR DESCRIPTION
Closes #243 

Remove sorting in ArborX. 

Use Unmanaged Kokkos::View. 
Simplify computation of characteristic length.