### PR TITLE
Update make minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 #
 
 message("CMakeLists.txt - NimbleSM")
+
+# Needed to specify the version of NimbleSM
+cmake_policy(set CMP0048 new)
+
 project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
 
 #--- Define options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,33 @@
 #
 
 message("CMakeLists.txt - NimbleSM")
-
-cmake_minimum_required(VERSION 3.12)
 project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
+
+#--- Define options
+option(HAVE_UQ "Whether to use enamble UQ sampling" OFF)
+option(HAVE_BVH "Whether to use BVH for parallel asynchronous contact" OFF)
+option(HAVE_TRILINOS "Whether to use Trilinos" OFF)
+option(HAVE_KOKKOS "Whether to use Kokkos for parallel execution" OFF)
+option(USE_PURE_MPI "Whether to use Pure MPI (no Trilinos)" OFF)
+option(NIMBLE_ENABLE_UNIT_TESTS "Whether to build Nimble with GTest testing" OFF)
+option(TIME_CONTACT "Whether to time contact" OFF)
+option(HAVE_ARBORX "Whether to use ArborX" OFF)
+
+#--- Set CMake minimum version
+if (HAVE_KOKKOS OR HAVE_TRILINOS)
+  cmake_minimum_required(VERSION 3.17)
+else()
+  cmake_minimum_required(VERSION 3.12)
+endif()
 
 include(GNUInstallDirs)
 
+### The following option may be deprecated
+option(NIMBLE_NVIDIA_BUILD "Whether to build Nimble with CUDA" OFF)
 if (NIMBLE_NVIDIA_BUILD)
   add_definitions(-DNIMBLE_NVIDIA_BUILD)
 endif()
+########################################
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -22,17 +40,6 @@ enable_testing()
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
-
-option(HAVE_UQ "Whether to use enamble UQ sampling" OFF)
-option(HAVE_BVH "Whether to use BVH for parallel asynchronous contact" OFF)
-option(HAVE_TRILINOS "Whether to use Trilinos" OFF)
-option(HAVE_KOKKOS "Whether to use Kokkos for parallel execution" OFF)
-option(USE_PURE_MPI "Whether to use Pure MPI (no Trilinos)" OFF)
-option(HAVE_QTHREADS "Whether to use QThreads" OFF)
-option(NIMBLE_NVIDIA_BUILD "Whether to build Nimble with CUDA" OFF)
-option(NIMBLE_ENABLE_UNIT_TESTS "Whether to build Nimble with GTest testing" OFF)
-option(TIME_CONTACT "Whether to time contact" OFF)
-option(HAVE_ARBORX "Whether to use ArborX" OFF)
 
 add_library(nimble)
 add_library(nimble::nimble ALIAS nimble)
@@ -111,14 +118,6 @@ if(HAVE_TRILINOS)
 else()
   message(STATUS "Trilinos is NOT enabled.")
   set(NIMBLE_HAVE_TRILINOS FALSE)
-endif()
-
-# Qthreads library dependencies
-if (HAVE_QTHREADS)
-  find_package(QThreads REQUIRED)
-  target_link_libraries(nimble PUBLIC QThreads::QThreads)
-  target_compile_definitions(nimble PUBLIC -DNIMBLE_HAVE_QTHREADS)
-  set(NIMBLE_HAVE_QTHREADS TRUE)
 endif()
 
 # Optional Kokkos dependency

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@
 
 message("CMakeLists.txt - NimbleSM")
 
-# Needed to specify the version of NimbleSM
-CMAKE_POLICY(SET CMP0048 NEW)
+#--- Set CMake minimum version
+cmake_minimum_required(VERSION 3.17)
 
 project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
 
@@ -18,9 +18,6 @@ option(USE_PURE_MPI "Whether to use Pure MPI (no Trilinos)" OFF)
 option(NIMBLE_ENABLE_UNIT_TESTS "Whether to build Nimble with GTest testing" OFF)
 option(TIME_CONTACT "Whether to time contact" OFF)
 option(HAVE_ARBORX "Whether to use ArborX" OFF)
-
-#--- Set CMake minimum version
-cmake_minimum_required(VERSION 3.17)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@
 
 message("CMakeLists.txt - NimbleSM")
 
-project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
-
 # Needed to specify the version of NimbleSM
 CMAKE_POLICY(SET CMP0048 NEW)
+
+project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
 
 #--- Define options
 option(HAVE_UQ "Whether to use enamble UQ sampling" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 message("CMakeLists.txt - NimbleSM")
 
 # Needed to specify the version of NimbleSM
-cmake_policy(set CMP0048 new)
+CMAKE_POLICY(SET CMP0048 NEW)
 
 project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@
 
 message("CMakeLists.txt - NimbleSM")
 
+project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
+
 # Needed to specify the version of NimbleSM
 CMAKE_POLICY(SET CMP0048 NEW)
-
-project(NimbleSM VERSION 0.1.0 LANGUAGES CXX)
 
 #--- Define options
 option(HAVE_UQ "Whether to use enamble UQ sampling" OFF)
@@ -20,20 +20,15 @@ option(TIME_CONTACT "Whether to time contact" OFF)
 option(HAVE_ARBORX "Whether to use ArborX" OFF)
 
 #--- Set CMake minimum version
-if (HAVE_KOKKOS OR HAVE_TRILINOS)
-  cmake_minimum_required(VERSION 3.17)
-else()
-  cmake_minimum_required(VERSION 3.12)
-endif()
+cmake_minimum_required(VERSION 3.17)
 
 include(GNUInstallDirs)
 
-### The following option may be deprecated
 option(NIMBLE_NVIDIA_BUILD "Whether to build Nimble with CUDA" OFF)
 if (NIMBLE_NVIDIA_BUILD)
-  add_definitions(-DNIMBLE_NVIDIA_BUILD)
+  message(WARNING "NVIDIA build is not currently active. ")
+  #add_definitions(-DNIMBLE_NVIDIA_BUILD)
 endif()
-########################################
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Update cmake to 3.17 when Kokkos and/or Trilinos is used
Remove obsolete QTHREADS flag.

Closes #232 