### PR TITLE
Create mailmap and update authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Alecto Irene Perez <perez.cs@pm.me> JAntonioPerezSandia <jorpere@sandia.gov>
+Alecto Irene Perez <perez.cs@pm.me> JAntonioPerezSandia <40574439+JAntonioPerezSandia@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,7 @@ NimbleSM authors:
 David J. Littlewood <djlittl@sandia.gov>
 Noah Evans <nevans@sandia.gov>
 Nicolas M. Morales <nmmoral@sandia.gov>
-J. Antonio Perez <jorpere@sandia.gov>
+Alecto Irene Perez <perez.cs@pm.me>
 Timothy Shelton <trshelt@sandia.gov>
 Daniel Sunderland <dsunder@sandia.gov>
 Patrick G. Xavier <pgxavie@sandia.gov>

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -20,8 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = u'NimbleSM'
-copyright = u'2018, David Littlewood, Nicolas Morales, Jorge Antonio Perez'
-author = u'David Littlewood, Nicolas Morales, Jorge Antonio Perez'
+copyright = u'2018, David Littlewood, Nicolas Morales, Alecto Irene Perez'
+author = u'David Littlewood, Nicolas Morales, Alecto Irene Perez'
 
 # The short X.Y version
 version = u''
@@ -140,7 +140,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'NimbleSM.tex', u'NimbleSM Documentation',
-     u'David Littlewood, Nicolas Morales, Jorge Antonio Perez', 'manual'),
+     u'David Littlewood, Nicolas Morales, Alecto Irene Perez', 'manual'),
 ]
 
 


### PR DESCRIPTION
This commit creates a .mailmap file for NimbleSM (see: https://git-scm.com/docs/gitmailmap), updating my name and contact info
to the correct version.

Having a mailmap ensures that author information is displayed correctly when looking through git log, and in other mailmap-aware programs.
