### PR TITLE
#293: ci-build-failures

### DIFF
--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -31,6 +31,8 @@ spack:
         - [$packages]
         - [$^mpis]
         - [$%compilers]
+  concretizer:
+    unify: true
   config:
     install_tree: /opt/software
   view: /opt/view

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -21,6 +21,8 @@ spack:
     - matrix:
         - [$packages]
         - [$%compilers]
+  concretizer:
+    unify: true
   config:
     install_tree: /opt/software
   view: /opt/view

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -32,7 +32,7 @@ RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https:
 
 # gcc ppa
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-
+#add patchelf for spack concretizer clingo
 RUN apt-get update \
   && apt-get install -y \
      gcc-11 \
@@ -44,6 +44,7 @@ RUN apt-get update \
      libncurses5-dev \
      m4 \
      perl \
+     patchelf \ 
   && rm -rf /var/lib/apt/lists/*
 
 # Now we install spack and find compilers/externals

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
       git \
       python3 \
+      python3-pip \
       python3-distutils \
       xz-utils \
       bzip2 \
@@ -44,9 +45,8 @@ RUN apt-get update \
      libncurses5-dev \
      m4 \
      perl \
-     patchelf \ 
   && rm -rf /var/lib/apt/lists/*
-
+RUN pip install clingo
 # Now we install spack and find compilers/externals
 RUN mkdir -p /opt/ && cd /opt/ && git clone https://github.com/spack/spack.git
 RUN . /opt/spack/share/spack/setup-env.sh && spack compiler find
@@ -62,7 +62,6 @@ RUN if [ "$NimbleSM_ENABLE_MPI" = "ON" ]; then \
 RUN cd /opt/spack-environment \
   && . /opt/spack/share/spack/setup-env.sh \
   && spack env activate . \
-  && spack bootstrap untrust github-actions-v0.2\
   && spack install --fail-fast \
   && spack gc -y
 

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -33,7 +33,7 @@ RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https:
 
 # gcc ppa
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-#add patchelf for spack concretizer clingo
+
 RUN apt-get update \
   && apt-get install -y \
      gcc-11 \

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -62,6 +62,7 @@ RUN if [ "$NimbleSM_ENABLE_MPI" = "ON" ]; then \
 RUN cd /opt/spack-environment \
   && . /opt/spack/share/spack/setup-env.sh \
   && spack env activate . \
+  && spack bootstrap untrust github-actions \
   && spack install --fail-fast \
   && spack gc -y
 

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -62,7 +62,7 @@ RUN if [ "$NimbleSM_ENABLE_MPI" = "ON" ]; then \
 RUN cd /opt/spack-environment \
   && . /opt/spack/share/spack/setup-env.sh \
   && spack env activate . \
-  && spack bootstrap untrust github-actions \
+  && spack bootstrap untrust github-actions-v0.2\
   && spack install --fail-fast \
   && spack gc -y
 


### PR DESCRIPTION
Spack v0.17 introduces a new concretizer and a new dependency clingo, which depends on patchelf.
Install patchelf before using spack in dockerfile.

Step towards closing #293.