### PR TITLE
#297: return failure code upon test failures

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,14 +1,7 @@
+set -e
 . /opt/spack/share/spack/setup-env.sh
 spack env activate nimble
 
 pushd /opt/build/NimbleSM
-testlist=(
-  "ctest --output-on-failure | tee ctest-output.log"
-)
-
-for this in "${testlist[@]}"; do
-  $this || flag=1
-done
-
+ctest --output-on-failure
 popd
-exit $flag

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,7 +2,13 @@
 spack env activate nimble
 
 pushd /opt/build/NimbleSM
+testlist=(
+  "ctest --output-on-failure | tee ctest-output.log"
+)
 
-ctest --output-on-failure
+for this in "${testlist[@]}"; do
+  $this || flag=1
+done
 
 popd
+exit $flag

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 . /opt/spack/share/spack/setup-env.sh
 spack env activate nimble


### PR DESCRIPTION
~~get ctest output log.~~(Artifacts will be saved in a separate PR) A failure code should be returned when tests fail so that the github runner does not take the docker command to be successful. 

Step towards closing #297.