### PR TITLE
#304: add state variables to getstress when using kokkos

### DIFF
--- a/src/nimble_kokkos_block_material_interface.cc
+++ b/src/nimble_kokkos_block_material_interface.cc
@@ -50,6 +50,18 @@ namespace nimble_kokkos {
 
 namespace {
 
+struct DeviceElemStateView
+{
+  //-- Variable to store one scalar per integration point
+  nimble_kokkos::DeviceScalarIntPtView scalar;
+  //-- Variable to store one scalar per integration point
+  nimble_kokkos::DeviceVectorIntPtView vec3D;
+  //-- Variable to store one scalar per integration point
+  nimble_kokkos::DeviceSymTensorIntPtView sym_tensor;
+  //-- Variable to store one scalar per integration point
+  nimble_kokkos::DeviceFullTensorIntPtView full_tensor;
+};
+
 inline void
 compute_block_stress(
     const nimble::BlockData&                        block_data,
@@ -57,13 +69,14 @@ compute_block_stress(
     const nimble_kokkos::DeviceFullTensorIntPtView& deformation_gradient_step_np1_d,
     const nimble_kokkos::DeviceSymTensorIntPtView&  stress_step_n_d,
     nimble_kokkos::DeviceSymTensorIntPtView         stress_step_np1_d,
+    const DeviceElemStateView&                      state_step_n_d,
+    DeviceElemStateView&                            state_step_np1_d,
     const double                                    time_n,
     const double                                    time_np1)
 {
-  auto      material_device = block_data.material_device;
-  auto      mdpolicy_2d     = make_elem_point_range_policy(block_data.num_elems, block_data.num_points_per_elem);
-  const int def_grad_len    = 9;
-  const int stress_len      = 6;
+  auto       material_device     = block_data.material_device;
+  auto       mdpolicy_2d         = make_elem_point_range_policy(block_data.num_elems, block_data.num_points_per_elem);
+  const auto num_state_variables = material_device->NumStateVariables();
   Kokkos::parallel_for(
       "Stress", mdpolicy_2d, KOKKOS_LAMBDA(const int i_elem, const int i_ipt) {
         auto element_deformation_gradient_step_n_d =
@@ -72,13 +85,36 @@ compute_block_stress(
             Kokkos::subview(deformation_gradient_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
         auto element_stress_step_n_d   = Kokkos::subview(stress_step_n_d, i_elem, i_ipt, Kokkos::ALL());
         auto element_stress_step_np1_d = Kokkos::subview(stress_step_np1_d, i_elem, i_ipt, Kokkos::ALL());
+        nimble::Material::DeviceElemState element_state_n_d, element_state_np1_d;
+        if (num_state_variables > 0) {
+          if (state_step_n_d.scalar.size() > 0)
+            element_state_n_d.scalar = Kokkos::subview(state_step_n_d.scalar, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_n_d.vec3D.size() > 0)
+            element_state_n_d.vec3D = Kokkos::subview(state_step_n_d.vec3D, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_n_d.sym_tensor.size() > 0)
+            element_state_n_d.sym_tensor = Kokkos::subview(state_step_n_d.sym_tensor, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_n_d.full_tensor.size() > 0)
+            element_state_n_d.full_tensor = Kokkos::subview(state_step_n_d.full_tensor, i_elem, i_ipt, Kokkos::ALL());
+          //
+          if (state_step_np1_d.scalar.size() > 0)
+            element_state_np1_d.scalar = Kokkos::subview(state_step_np1_d.scalar, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_np1_d.vec3D.size() > 0)
+            element_state_np1_d.vec3D = Kokkos::subview(state_step_np1_d.vec3D, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_np1_d.sym_tensor.size() > 0)
+            element_state_np1_d.sym_tensor = Kokkos::subview(state_step_np1_d.sym_tensor, i_elem, i_ipt, Kokkos::ALL());
+          if (state_step_np1_d.full_tensor.size() > 0)
+            element_state_np1_d.full_tensor =
+                Kokkos::subview(state_step_np1_d.full_tensor, i_elem, i_ipt, Kokkos::ALL());
+        }
         material_device->GetStress(
             time_n,
             time_np1,
             element_deformation_gradient_step_n_d,
             element_deformation_gradient_step_np1_d,
             element_stress_step_n_d,
-            element_stress_step_np1_d);
+            element_stress_step_np1_d,
+            element_state_n_d,
+            element_state_np1_d);
       });
 }
 
@@ -111,15 +147,50 @@ BlockMaterialInterface::ComputeStress() const
         model_data->GetDeviceSymTensorIntegrationPointData(block_data.id, field_ids.stress, nimble::STEP_N);
     auto stress_step_np1_d =
         model_data->GetDeviceSymTensorIntegrationPointData(block_data.id, field_ids.stress, nimble::STEP_NP1);
+    //
+    auto                material_device = block_data.material_device;
+    DeviceElemStateView elem_state_n, elem_state_np1;
+    if (material_device->NumStateVariables() > 0) {
+      if (field_ids.state_scalar >= 0) {
+        elem_state_n.scalar =
+            model_data->GetDeviceScalarIntegrationPointData(block_data.id, field_ids.state_scalar, nimble::STEP_N);
+        elem_state_np1.scalar =
+            model_data->GetDeviceScalarIntegrationPointData(block_data.id, field_ids.state_scalar, nimble::STEP_NP1);
+      }
+      //
+      if (field_ids.state_vec3D >= 0) {
+        elem_state_n.vec3D =
+            model_data->GetDeviceVectorIntegrationPointData(block_data.id, field_ids.state_vec3D, nimble::STEP_N);
+        elem_state_np1.vec3D =
+            model_data->GetDeviceVectorIntegrationPointData(block_data.id, field_ids.state_vec3D, nimble::STEP_NP1);
+      }
+      //
+      if (field_ids.state_sym_tensor >= 0) {
+        elem_state_n.sym_tensor = model_data->GetDeviceSymTensorIntegrationPointData(
+            block_data.id, field_ids.state_sym_tensor, nimble::STEP_N);
+        elem_state_np1.sym_tensor = model_data->GetDeviceSymTensorIntegrationPointData(
+            block_data.id, field_ids.state_sym_tensor, nimble::STEP_NP1);
+      }
+      //
+      if (field_ids.state_full_tensor >= 0) {
+        elem_state_n.full_tensor = model_data->GetDeviceFullTensorIntegrationPointData(
+            block_data.id, field_ids.state_full_tensor, nimble::STEP_N);
+        elem_state_np1.full_tensor = model_data->GetDeviceFullTensorIntegrationPointData(
+            block_data.id, field_ids.state_full_tensor, nimble::STEP_NP1);
+      }
+    }
+    //
     compute_block_stress(
         block_data,
         deformation_gradient_step_n_d,
         deformation_gradient_step_np1_d,
         stress_step_n_d,
         stress_step_np1_d,
+        elem_state_n,
+        elem_state_np1,
         time_n,
         time_np1);
-  }
+  }  // for (auto&& block_data : blocks)
 }
 
 }  // namespace nimble_kokkos

--- a/src/nimble_kokkos_defs.h
+++ b/src/nimble_kokkos_defs.h
@@ -95,6 +95,8 @@ enum class FieldType : int
   DeviceSymTensorIntPt,
   HostFullTensorIntPt,
   DeviceFullTensorIntPt,
+  DeviceScalarIntPt,
+  DeviceVectorIntPt,
   HostScalarElem,
   DeviceScalarElem,
   HostSymTensorElem,
@@ -115,6 +117,8 @@ operator<<(std::ostream& out, const FieldType f)
     case FieldType::DeviceSymTensorIntPt: out << "DeviceSymTensorIntPt"; break;
     case FieldType::HostFullTensorIntPt: out << "HostFullTensorIntPt"; break;
     case FieldType::DeviceFullTensorIntPt: out << "DeviceFullTensorIntPt"; break;
+    case FieldType::DeviceScalarIntPt: out << "DeviceScalarIntPt"; break;
+    case FieldType::DeviceVectorIntPt: out << "DeviceVectorIntPt"; break;
     case FieldType::HostScalarElem: out << "HostScalarElem"; break;
     case FieldType::DeviceScalarElem: out << "DeviceScalarElem"; break;
     case FieldType::HostSymTensorElem: out << "HostSymTensorElem"; break;
@@ -366,6 +370,58 @@ class Field<FieldType::DeviceFullTensorIntPt> : public FieldBase
 };
 
 template <>
+class Field<FieldType::DeviceScalarIntPt> : public FieldBase
+{
+ public:
+  // (elem, ipt, scalar)
+  using View            = Kokkos::View<double* [NUM_INTEGRATION_POINTS_IN_HEX][1], kokkos_layout, kokkos_device>;
+  using SubView         = decltype(Kokkos::subview(*(View*)(0), (int)(0), Kokkos::ALL, Kokkos::ALL));
+  using SingleEntryView = decltype(Kokkos::subview(*(View*)(0), (int)(0), (int)(0), Kokkos::ALL));
+
+  Field(const std::string& name, int num_entries)
+      : FieldBase(name, FieldType::DeviceFullTensorIntPt), data_(name, num_entries)
+  {
+  }
+
+  Field(View const& v) : FieldBase(v.label(), FieldType::DeviceFullTensorIntPt), data_(v) {}
+
+  View
+  data() const noexcept
+  {
+    return data_;
+  }
+
+ private:
+  View data_;
+};
+
+template <>
+class Field<FieldType::DeviceVectorIntPt> : public FieldBase
+{
+ public:
+  // (elem, ipt, vector_index)
+  using View            = Kokkos::View<double* [NUM_INTEGRATION_POINTS_IN_HEX][3], kokkos_layout, kokkos_device>;
+  using SubView         = decltype(Kokkos::subview(*(View*)(0), (int)(0), Kokkos::ALL, Kokkos::ALL));
+  using SingleEntryView = decltype(Kokkos::subview(*(View*)(0), (int)(0), (int)(0), Kokkos::ALL));
+
+  Field(const std::string& name, int num_entries)
+      : FieldBase(name, FieldType::DeviceFullTensorIntPt), data_(name, num_entries)
+  {
+  }
+
+  Field(View const& v) : FieldBase(v.label(), FieldType::DeviceFullTensorIntPt), data_(v) {}
+
+  View
+  data() const noexcept
+  {
+    return data_;
+  }
+
+ private:
+  View data_;
+};
+
+template <>
 class Field<FieldType::HostScalarElem> : public FieldBase
 {
  public:
@@ -535,6 +591,12 @@ typedef Field<FieldType::DeviceFullTensorIntPt>::SingleEntryView DeviceFullTenso
 typedef Field<FieldType::DeviceSymTensorIntPt>::View             DeviceSymTensorIntPtView;
 typedef Field<FieldType::DeviceSymTensorIntPt>::SubView          DeviceSymTensorIntPtSubView;
 typedef Field<FieldType::DeviceSymTensorIntPt>::SingleEntryView  DeviceSymTensorIntPtSingleEntryView;
+typedef Field<FieldType::DeviceScalarIntPt>::View                DeviceScalarIntPtView;
+typedef Field<FieldType::DeviceScalarIntPt>::SubView             DeviceScalarIntPtSubView;
+typedef Field<FieldType::DeviceScalarIntPt>::SingleEntryView     DeviceScalarIntPtSingleEntryView;
+typedef Field<FieldType::DeviceVectorIntPt>::View                DeviceVectorIntPtView;
+typedef Field<FieldType::DeviceVectorIntPt>::SubView             DeviceVectorIntPtSubView;
+typedef Field<FieldType::DeviceVectorIntPt>::SingleEntryView     DeviceVectorIntPtSingleEntryView;
 typedef Field<FieldType::DeviceScalarElem>::View                 DeviceScalarElemView;
 typedef Field<FieldType::DeviceScalarElem>::SingleEntryView      DeviceScalarElemSingleEntryView;
 typedef Field<FieldType::DeviceFullTensorElem>::View             DeviceFullTensorElemView;

--- a/src/nimble_kokkos_model_data.h
+++ b/src/nimble_kokkos_model_data.h
@@ -235,6 +235,12 @@ class ModelData : public nimble::ModelDataBase
   DeviceFullTensorIntPtView
   GetDeviceFullTensorIntegrationPointData(int block_id, int field_id, nimble::Step step);
 
+  DeviceScalarIntPtView
+  GetDeviceScalarIntegrationPointData(int block_id, int field_id, nimble::Step step);
+
+  DeviceVectorIntPtView
+  GetDeviceVectorIntegrationPointData(int block_id, int field_id, nimble::Step step);
+
   DeviceScalarElemView
   GetDeviceScalarElementData(int block_id, int field_id);
 
@@ -295,6 +301,14 @@ class ModelData : public nimble::ModelDataBase
   /// \param data_manager
   void
   InitializeBlockData(nimble::DataManager& data_manager);
+
+  template <FieldType ft>
+  typename Field<ft>::View
+  GetDeviceElementData(int block_id, int field_id);
+
+  template <FieldType ft>
+  typename Field<ft>::View
+  GetDeviceIntPointData(int block_id, int field_id, nimble::Step step);
 
  protected:
   using Data = std::unique_ptr<FieldBase>;

--- a/src/nimble_model_data_base.h
+++ b/src/nimble_model_data_base.h
@@ -77,6 +77,11 @@ struct FieldIds
   int internal_force = -1;
   int contact_force  = -1;
   int external_force = -1;
+
+  int state_scalar      = -1;
+  int state_vec3D       = -1;
+  int state_sym_tensor  = -1;
+  int state_full_tensor = -1;
 };
 
 class ModelDataBase


### PR DESCRIPTION
Use Kokkos variables to store state variables when the material needs state variables.
Introduce a structure that would store a scalar, a vector (dim 3), a symmetric tensor (dim 6), a full tensor (dim 9) if needed.

Please comment if the changes are incomplete.