### PR TITLE
#318: set arch to be compliant with all current github runner platforms

### DIFF
--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -1,6 +1,5 @@
 spack:
   definitions:
-    - arch: [x86_64]
     - compilers: [gcc@11.1.0]
     - mpis:
         - mpich@3.4.2
@@ -25,16 +24,16 @@ spack:
     - matrix:
         - [$mpis]
         - [$%compilers]
-        - [$arch]
+        - [arch=linux-ubuntu20.04-x86_64_v3]
     - matrix:
         - [$core-packages]
         - [$%compilers]
-        - [$arch]
+        - [arch=linux-ubuntu20.04-x86_64_v3]
     - matrix:
         - [$packages]
         - [$^mpis]
         - [$%compilers]
-        - [$arch]
+        - [arch=linux-ubuntu20.04-x86_64_v3]
   concretizer:
     unify: true
   config:

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -25,13 +25,16 @@ spack:
     - matrix:
         - [$mpis]
         - [$%compilers]
+        - [$arch]
     - matrix:
         - [$core-packages]
         - [$%compilers]
+        - [$arch]
     - matrix:
         - [$packages]
         - [$^mpis]
         - [$%compilers]
+        - [$arch]
   concretizer:
     unify: true
   config:

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -1,6 +1,6 @@
 spack:
   definitions:
-    - arch: [haswell]
+    - arch: [x86_64]
     - compilers: [gcc@11.1.0]
     - mpis:
         - mpich@3.4.2

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -1,7 +1,7 @@
 spack:
   definitions:
+    - arch: [haswell]
     - compilers: [gcc@11.1.0]
-    - target: [haswell]
     - mpis:
         - mpich@3.4.2
     - core-packages: []

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -1,6 +1,7 @@
 spack:
   definitions:
     - compilers: [gcc@11.1.0]
+    - target: [haswell]
     - mpis:
         - mpich@3.4.2
     - core-packages: []

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,7 +1,7 @@
 spack:
   definitions:
+    - arch: [haswell]
     - compilers: [gcc@11.1.0]
-    - target: [haswell]
     - packages: []
     - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"
       packages:

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -22,6 +22,7 @@ spack:
     - matrix:
         - [$packages]
         - [$%compilers]
+        - [$arch]
   concretizer:
     unify: true
   config:

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,6 +1,7 @@
 spack:
   definitions:
     - compilers: [gcc@11.1.0]
+    - target: [haswell]
     - packages: []
     - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"
       packages:

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,6 +1,5 @@
 spack:
   definitions:
-    - arch: [x86_64_v3]
     - compilers: [gcc@11.1.0]
     - packages: []
     - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"
@@ -22,7 +21,7 @@ spack:
     - matrix:
         - [$packages]
         - [$%compilers]
-        - [$arch]
+        - [arch=linux-ubuntu20.04-x86_64_v3]
   concretizer:
     unify: true
   config:

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,6 +1,6 @@
 spack:
   definitions:
-    - arch: [haswell]
+    - arch: [x86_64_v3]
     - compilers: [gcc@11.1.0]
     - packages: []
     - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"


### PR DESCRIPTION
Set architecture target to Haswell to avoid AVX512 instructions.