### PR TITLE
#322: Improve clarity of CI error messages

### DIFF
--- a/.github/workflows/main-doxygen-deploy.yml
+++ b/.github/workflows/main-doxygen-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
         
     - name: Doxygen Action
       uses: mattnotmitt/doxygen-action@v1.1.0

--- a/.github/workflows/main-doxygen.yml
+++ b/.github/workflows/main-doxygen.yml
@@ -20,10 +20,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
         
     - name: Doxygen Action
-      uses: mattnotmitt/doxygen-action@v1.1.0
+      uses: mattnotmitt/doxygen-action@v1.9.4
       with:
         # Path to Doxyfile
         doxyfile-path: "./docs/doxygen/.Doxyfile_for_Deployment" # default is ./Doxyfile

--- a/.github/workflows/ubuntu20.04-gcc11-x64-UQ-on.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64-UQ-on.yml
@@ -26,13 +26,13 @@ jobs:
             kokkos: {name: "", value: "OFF"}
     name: NimbleSM ${{ matrix.mpi.name }}${{ matrix.kokkos.name }}${{ matrix.trilinos.name }}${{ matrix.uq.name }}${{ matrix.arborx.name }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: CI Variables
         id: vars
         run: echo "::set-output name=docker_tag::$(git rev-parse --abbrev-ref ${{ github.head_ref || github.ref || 'HEAD' }} | sed 's/[^a-z0-9_-]/__/gi')"
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Inspect builder
         run: |
           echo "Name:      ${{ steps.buildx.outputs.name }}"

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -78,7 +78,5 @@ jobs:
         run: |
           echo "Success Flag with 0 pass and 1 fail:"
           cat ${{ env.OUTPUT_DIR }}/tmp/artifacts/success_flag.txt
-          echo "docker_build_outcome:  ${{ steps.docker_build.outcome }}"
-          echo "docker_build_conclusion:  ${{ steps.docker_build.conclusion }}"
           if [[  $(cat ${{ env.OUTPUT_DIR }}/tmp/artifacts/success_flag.txt) -eq 0 ]]; then exit 0; else exit 1; fi
         shell: bash

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "DOCKER_TAG=$(echo ${{ github.ref }} | cut -d'/' -f3- | sed 's/[^a-z0-9_-]/__/gi')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Inspect Builder
         run: |
           echo "Name:      ${{ steps.buildx.outputs.name }}"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -14,4 +14,6 @@ cp /opt/build/NimbleSM/Testing/Temporary/LastTest.log /tmp/artifacts/
 cp /opt/build/NimbleSM/test/*/*/*.log /tmp/artifacts/
 echo ${success_flag} > /tmp/artifacts/success_flag.txt
 ls /tmp/artifacts
+# Simply output the LastTest.log to screen
+cat /opt/build/NimbleSM/Testing/Temporary/LastTest.log
 popd

--- a/test/run_exodiff_test.py
+++ b/test/run_exodiff_test.py
@@ -66,12 +66,14 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
     print("\nCommand:", command)
 
     # run the code
-    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+    p = run(command, capture_output=True, text=True, check=True)
     return_code = p.returncode
     if return_code != 0:
         result = return_code
-    logfile.write("------------FIRST TEST RESULT " + str(result) + "\n\n")
-    logfile.flush()
+    print("stdout:", p.stdout)
+    print("stderr:", p.stderr)
+    # logfile.write("------------FIRST TEST RESULT " + str(result) + "\n\n")
+    # logfile.flush()
     # run epu
     if epu_required:
         command = ["epu", \
@@ -81,12 +83,16 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                    epu_output_extension, \
                    nimble_output_name]
         print("EPU COMMAND", command)
-        p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+        p = run(command, capture_output=True, text=True, check=True)
         return_code = p.returncode
         if return_code != 0:
             result = return_code
-    logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
-    logfile.flush()
+
+    # logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
+    # logfile.flush()
+    print("stdout:", p.stdout)
+    print("stderr:", p.stderr)
+
     # run exodiff
     command = ["exodiff", \
                "-stat", \
@@ -94,15 +100,16 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                base_name+".exodiff", \
                base_name+".gold.e", \
                epu_exodus_output_name]
-    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+    p = run(command, capture_output=True, text=True, check=True)
     return_code = p.returncode
     if return_code != 0:
         result = return_code
+    print("stdout:", p.stdout)
+    print("stderr:", p.stderr)
+    # logfile.write("FINAL TEST RESULT " + str(result) + "\n\n")
+    # logfile.flush()
 
-    logfile.write("FINAL TEST RESULT " + str(result) + "\n\n")
-    logfile.flush()
-
-    logfile.close()
+    # logfile.close()
 
     return result
 

--- a/test/run_exodiff_test.py
+++ b/test/run_exodiff_test.py
@@ -66,14 +66,13 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
     print("\nCommand:", command)
 
     # run the code
-    p = run(command, capture_output=True, text=True, check=True)
+    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
     return_code = p.returncode
     if return_code != 0:
         result = return_code
-    print("stdout:", p.stdout)
-    print("stderr:", p.stderr)
-    # logfile.write("------------FIRST TEST RESULT " + str(result) + "\n\n")
-    # logfile.flush()
+
+    logfile.write("------------FIRST TEST RESULT " + str(result) + "\n\n")
+    logfile.flush()
     # run epu
     if epu_required:
         command = ["epu", \
@@ -83,15 +82,13 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                    epu_output_extension, \
                    nimble_output_name]
         print("EPU COMMAND", command)
-        p = run(command, capture_output=True, text=True, check=True)
+        p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
         return_code = p.returncode
         if return_code != 0:
             result = return_code
 
-    # logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
-    # logfile.flush()
-    print("stdout:", p.stdout)
-    print("stderr:", p.stderr)
+    logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
+    logfile.flush()
 
     # run exodiff
     command = ["exodiff", \
@@ -100,16 +97,15 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                base_name+".exodiff", \
                base_name+".gold.e", \
                epu_exodus_output_name]
-    p = run(command, capture_output=True, text=True, check=True)
+    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
     return_code = p.returncode
     if return_code != 0:
         result = return_code
-    print("stdout:", p.stdout)
-    print("stderr:", p.stderr)
-    # logfile.write("FINAL TEST RESULT " + str(result) + "\n\n")
-    # logfile.flush()
 
-    # logfile.close()
+    logfile.write("FINAL TEST RESULT " + str(result) + "\n\n")
+    logfile.flush()
+
+    logfile.close()
 
     return result
 

--- a/test/run_exodiff_test.py
+++ b/test/run_exodiff_test.py
@@ -66,13 +66,20 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
     print("\nCommand:", command)
 
     # run the code
-    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+    p = run(command, capture_output=True, text=True, check=True)
+    print("stdout:", p.stdout)
+    print("stderr:", p.stderr)
+
     return_code = p.returncode
     if return_code != 0:
         result = return_code
 
+    print("------------FIRST TEST RESULT " + str(result) + "\n\n")
     logfile.write("------------FIRST TEST RESULT " + str(result) + "\n\n")
+    logfile.write(p.stdout)
+    logfile.write(p.stderr)
     logfile.flush()
+
     # run epu
     if epu_required:
         command = ["epu", \
@@ -82,13 +89,19 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                    epu_output_extension, \
                    nimble_output_name]
         print("EPU COMMAND", command)
-        p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+        p = run(command, capture_output=True, text=True, check=True)
+        print("stdout:", p.stdout)
+        print("stderr:", p.stderr)
+
         return_code = p.returncode
         if return_code != 0:
             result = return_code
 
-    logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
-    logfile.flush()
+        print("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
+        logfile.write("------------SECOND(MPI) TEST RESULT " + str(result) + "\n\n")
+        logfile.write(p.stdout)
+        logfile.write(p.stderr)
+        logfile.flush()
 
     # run exodiff
     command = ["exodiff", \
@@ -97,12 +110,18 @@ def runtestdiff(executable_name, cli_flag, input_deck_name, num_ranks, use_openm
                base_name+".exodiff", \
                base_name+".gold.e", \
                epu_exodus_output_name]
-    p = run(command, stdout=logfile, stderr=logfile, text=True, check=True)
+    p = run(command, capture_output=True, text=True, check=True)
+    print("stdout:", p.stdout)
+    print("stderr:", p.stderr)
+
     return_code = p.returncode
     if return_code != 0:
         result = return_code
 
+    print("FINAL TEST RESULT " + str(result) + "\n\n")
     logfile.write("FINAL TEST RESULT " + str(result) + "\n\n")
+    logfile.write(p.stdout)
+    logfile.write(p.stderr)
     logfile.flush()
 
     logfile.close()


### PR DESCRIPTION
Improve the clarity of error messages, by displaying the test logs to the Github UI and generating files of the logs. Additionally update github actions to eliminate deprecation warnings. 

Step towards closing #322. 