### PR TITLE
Setup dependencies for plasticity material model

### DIFF
--- a/ci/arborx_spack_package.patch
+++ b/ci/arborx_spack_package.patch
@@ -1,0 +1,12 @@
+diff --git a/var/spack/repos/builtin/packages/arborx/package.py b/var/spack/repos/builtin/packages/arborx/package.py
+index 8888380d..5da92597 100644
+--- a/var/spack/repos/builtin/packages/arborx/package.py
++++ b/var/spack/repos/builtin/packages/arborx/package.py
+@@ -18,6 +18,7 @@ class Arborx(CMakePackage, CudaPackage, ROCmPackage):
+     maintainers("aprokop")
+ 
+     version("master", branch="master")
++    version("1.4.1", sha256="2ca828ef6615859654b233a7df17017e7cfd904982b80026ec7409eb46b77a95")
+     version("1.3", sha256="3f1e17f029a460ab99f8396e2772cec908eefc4bf3868c8828907624a2d0ce5d")
+     version("1.2", sha256="ed1939110b2330b7994dcbba649b100c241a2353ed2624e627a200a398096c20")
+     version("1.1", sha256="2b5f2d2d5cec57c52f470c2bf4f42621b40271f870b4f80cb57e52df1acd90ce")

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,6 +6,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_C_COMPILER=gcc-11 \
      -DCMAKE_CXX_COMPILER=g++-11 \
      -DCMAKE_CXX_FLAGS="-Werror" \
+     -DCMAKE_PREFIX_PATH=/opt/local \
      -DNimbleSM_ENABLE_UNIT_TESTS=ON \
      -DNimbleSM_ENABLE_MPI=$NimbleSM_ENABLE_MPI \
      -DNimbleSM_ENABLE_KOKKOS=$NimbleSM_ENABLE_KOKKOS \

--- a/ci/install-mpicpp.sh
+++ b/ci/install-mpicpp.sh
@@ -1,0 +1,11 @@
+set -x
+
+. /opt/spack/share/spack/setup-env.sh
+spack env activate nimble
+
+git clone https://github.com/sandialabs/mpicpp.git /opt/src/mpicpp
+cd /opt/src/mpicpp && git checkout db872e297a311a5ad361868d1f74e054b7877b68 && cd -
+
+cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/opt/local -S /opt/src/mpicpp -B /opt/build/mpicpp
+cmake --build /opt/build/mpicpp --parallel $(nproc)
+cmake --build /opt/build/mpicpp --target install

--- a/ci/install-p3a.sh
+++ b/ci/install-p3a.sh
@@ -1,0 +1,11 @@
+set -x
+
+. /opt/spack/share/spack/setup-env.sh
+spack env activate nimble
+
+git clone https://github.com/sandialabs/p3a.git /opt/src/p3a
+cd /opt/src/p3a && git checkout ee33b596b16a3baba629859096bb42de00bb8bd3 && cd -
+
+cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/opt/local -D CMAKE_PREFIX_PATH=/opt/local -S /opt/src/p3a -B /opt/build/p3a
+cmake --build /opt/build/p3a --parallel $(nproc)
+cmake --build /opt/build/p3a --target install

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -11,7 +11,7 @@ spack:
         - trilinos@14.0.0 +openmp +exodus
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
-        - seacas@2022-10-14 -x11 ^hdf5 ^fmt
+        - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
         - arborx@1.1 +openmp +mpi +trilinos

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -11,6 +11,7 @@ spack:
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       core-packages:
         - kokkos@4.0 +openmp +serial
+    - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
         - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -3,14 +3,12 @@ spack:
     - compilers: [gcc@11.1.0]
     - mpis:
         - mpich@3.4.2
-    - core-packages: []
+    - core-packages:
+        - kokkos@4.0 +openmp +serial
     - packages: []
-    - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"
-      core-packages:
-        - kokkos@3.6 +openmp +serial
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:
-        - trilinos@13.2.0 +openmp +exodus
+        - trilinos@14.0.0 +openmp +exodus
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
         - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -1,6 +1,6 @@
 spack:
   definitions:
-    - compilers: [gcc@11.1.0]
+    - compilers: [gcc@11.4.0]
     - mpis:
         - mpich@3.4.2
     - core-packages:

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -16,10 +16,10 @@ spack:
         - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
-        - arborx@1.1 +openmp +mpi +trilinos
+        - arborx@1.4.1 +openmp +mpi +trilinos
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "OFF" )
       packages:
-        - arborx@1.1 +openmp +mpi
+        - arborx@1.4.1 +openmp +mpi
   specs:
     - matrix:
         - [$mpis]

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -3,6 +3,7 @@ spack:
     - compilers: [gcc@11.4.0]
     - mpis:
         - mpich@3.4.2
+    - core-packages: []
     - packages: []
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -11,7 +11,7 @@ spack:
         - trilinos@14.0.0 +openmp +exodus
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
-        - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0
+        - seacas@2022-10-14 -x11 ^hdf5 ^fmt
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
         - arborx@1.1 +openmp +mpi +trilinos

--- a/ci/spack-depends-mpi.yml
+++ b/ci/spack-depends-mpi.yml
@@ -3,13 +3,13 @@ spack:
     - compilers: [gcc@11.4.0]
     - mpis:
         - mpich@3.4.2
-    - core-packages:
-        - kokkos@4.0 +openmp +serial
     - packages: []
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:
         - trilinos@14.0.0 +openmp +exodus
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
+      core-packages:
+        - kokkos@4.0 +openmp +serial
       packages:
         - seacas@2022-10-14 -x11 ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -6,7 +6,7 @@ spack:
         - mpich@3.4.2
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:
-        - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi
+        - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi ^cgns~mpi
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
         - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -2,13 +2,13 @@ spack:
   definitions:
     - compilers: [gcc@11.4.0]
     - packages:
-        - kokkos@4.0 +openmp +serial
         - mpich@3.4.2
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:
         - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi ^cgns~mpi
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
+        - kokkos@4.0 +openmp +serial
         - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -12,10 +12,10 @@ spack:
         - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
-        - arborx@1.1 +openmp -mpi +trilinos
+        - arborx@1.4.1 +openmp -mpi +trilinos
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "OFF" )
       packages:
-        - arborx@1.1 +openmp -mpi
+        - arborx@1.4.1 +openmp -mpi
   specs:
     - matrix:
         - [$packages]

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -9,7 +9,7 @@ spack:
         - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
-        - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0
+        - seacas@2022-10-14 -x11 -mpi ^hdf5 ^fmt
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
         - arborx@1.1 +openmp -mpi +trilinos

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,6 +1,6 @@
 spack:
   definitions:
-    - compilers: [gcc@11.1.0]
+    - compilers: [gcc@11.4.0]
     - packages:
         - kokkos@4.0 +openmp +serial
         - mpich@3.4.2

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -9,7 +9,7 @@ spack:
         - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
-        - seacas@2022-10-14 -x11 -mpi ^hdf5 ^fmt
+        - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0
     - when: ( env["NimbleSM_ENABLE_ARBORX"] == "ON" ) and ( env["NimbleSM_ENABLE_TRILINOS"] == "ON" )
       packages:
         - arborx@1.1 +openmp -mpi +trilinos

--- a/ci/spack-depends-serial.yml
+++ b/ci/spack-depends-serial.yml
@@ -1,13 +1,12 @@
 spack:
   definitions:
     - compilers: [gcc@11.1.0]
-    - packages: []
-    - when: env["NimbleSM_ENABLE_KOKKOS"] == "ON"
-      packages:
-        - kokkos@3.6 +openmp
+    - packages:
+        - kokkos@4.0 +openmp +serial
+        - mpich@3.4.2
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "ON"
       packages:
-        - trilinos@13.2.0 +openmp +exodus -mpi ^hdf5~mpi
+        - trilinos@14.0.0 +openmp +exodus -mpi ^hdf5~mpi
     - when: env["NimbleSM_ENABLE_TRILINOS"] == "OFF"
       packages:
         - seacas@2022-10-14 -x11 -mpi ^hdf5@1.14.1 ^fmt@9.1.0

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -68,7 +68,6 @@ RUN . /opt/spack/share/spack/setup-env.sh && spack env create nimble /opt/spack/
 # activate nimble env and install
 RUN . /opt/spack/share/spack/setup-env.sh && spack env activate nimble && spack install --fail-fast && spack gc -y
 
-
 FROM build_dependencies-stage as build_nimble-stage
 # need to be repeated in the new stage
 ARG NimbleSM_ENABLE_MPI
@@ -80,6 +79,10 @@ ARG NimbleSM_ENABLE_ARBORX
 # Add current source dir into the image
 COPY . /opt/src/NimbleSM
 RUN mkdir -p /opt/build/NimbleSM
+
+# install mpicpp and p3a
+RUN bash /opt/src/NimbleSM/ci/install-mpicpp.sh
+RUN bash /opt/src/NimbleSM/ci/install-p3a.sh
 
 # Build using the spack environment we created
 RUN bash /opt/src/NimbleSM/ci/build.sh

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -49,6 +49,13 @@ RUN apt-get update \
 RUN pip install clingo
 # Now we install spack and find compilers/externals
 RUN mkdir -p /opt/ && cd /opt/ && git clone --depth 1 --branch "v0.20.1" https://github.com/spack/spack.git
+
+# Add current source dir into the image
+COPY . /opt/src/NimbleSM
+
+# Apply our patch to get more up-to-date packages
+RUN cd /opt/spack && git apply /opt/src/NimbleSM/ci/arborx_spack_package.patch
+
 RUN . /opt/spack/share/spack/setup-env.sh && spack compiler find
 RUN . /opt/spack/share/spack/setup-env.sh && spack external find --not-buildable && spack external list
 RUN mkdir -p /opt/spack-environment
@@ -76,8 +83,6 @@ ARG NimbleSM_ENABLE_TRILINOS
 ARG NimbleSM_ENABLE_UQ
 ARG NimbleSM_ENABLE_ARBORX
 
-# Add current source dir into the image
-COPY . /opt/src/NimbleSM
 RUN mkdir -p /opt/build/NimbleSM
 
 # install mpicpp and p3a

--- a/ci/ubuntu20.04-gcc11-x64.dockerfile
+++ b/ci/ubuntu20.04-gcc11-x64.dockerfile
@@ -36,11 +36,11 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 
 RUN apt-get update \
   && apt-get install -y \
-     gcc-11 \
-     g++-11 \
-     gfortran-11 \
-     cmake-data=3.21.3-0kitware1ubuntu20.04.1 \
-     cmake=3.21.3-0kitware1ubuntu20.04.1 \
+     gcc-11=11.4.0-2ubuntu1~20.04 \
+     g++-11=11.4.0-2ubuntu1~20.04 \
+     gfortran-11=11.4.0-2ubuntu1~20.04 \
+     cmake-data=3.26.4-0kitware1ubuntu20.04.1 \
+     cmake=3.26.4-0kitware1ubuntu20.04.1 \
      pkg-config \
      libncurses5-dev \
      m4 \

--- a/unit_tests/nimble_unit_main.cc
+++ b/unit_tests/nimble_unit_main.cc
@@ -57,7 +57,7 @@ main(int argc, char** argv)
   int err = RUN_ALL_TESTS();
 
 #ifdef NIMBLE_HAVE_KOKKOS
-  Kokkos::finalize_all();
+  Kokkos::finalize();
 #endif
 
   return err;


### PR DESCRIPTION
-   Make Kokkos and MPI universal requirements for all builds
-   Use Kokkos version 4 since p3a requires Kokkos_SIMD.hpp
-   Use Trilinos version 14 since it supplies Kokkos version 4
-   Add scripts for installing mpicpp and p3a